### PR TITLE
Refactor/01 kiss dry asap

### DIFF
--- a/public/data/experiences.json
+++ b/public/data/experiences.json
@@ -10,7 +10,7 @@
       "title": "Senior QA Engineer",
       "company": "InPost",
       "time": "Sep 2025 – Present",
-      "description": "Develop and maintain automated test coverage across web, mobile, backend, and performance layers. Support Playwright UI tests in TypeScript, WebdriverIO automation for native mobile apps, and Kotlin-based backend, contract, and end-to-end testing frameworks. Contribute to Gatling performance testing, test reporting, documentation, and actionable defect analysis."
+      "description": "Build and maintain automated quality coverage across web, mobile, backend, contract and performance layers. Work with Playwright in TypeScript, WebdriverIO for native mobile apps, Kotlin-based backend test frameworks and Gatling performance checks. Provide quality reporting, documentation and clear defect analysis that supports release decisions."
     },
     {
       "title": "Test Engineer Expert",

--- a/src/config/profile.js
+++ b/src/config/profile.js
@@ -1,0 +1,19 @@
+export const profile = {
+  name: "Rafal Ciesielski",
+  brand: "Quality Engineering",
+  heroRole: "Quality Engineering Specialist",
+  currentFocus: "Quality engineering, automation and product delivery.",
+  links: {
+    github: "https://github.com/rciesielski3",
+    linkedin: "https://www.linkedin.com/in/rafa%C5%82-ciesielski-820309100/",
+  },
+};
+
+export const navigationItems = [
+  { label: "Home", path: "/" },
+  { label: "Experience", path: "/experience" },
+  { label: "Skills", path: "/skills" },
+  { label: "Certifications", path: "/courses" },
+  { label: "GitHub", path: "/github" },
+  { label: "Contact", path: "/contact" },
+];

--- a/src/features/contact/ContactForm.jsx
+++ b/src/features/contact/ContactForm.jsx
@@ -1,15 +1,51 @@
 import React, { useState } from "react";
 import emailjs from "emailjs-com";
-import { FaGithub, FaLinkedin } from "react-icons/fa";
+import SocialLinks from "../../shared/SocialLinks";
 import "./ContactForm.css";
 
+const initialFormData = {
+  first_name: "",
+  title: "",
+  senderEmail: "",
+  message: "",
+};
+
+const emailPattern = /\S+@\S+\.\S+/;
+
+const formFields = [
+  {
+    id: "first_name",
+    label: "Name",
+    type: "text",
+  },
+  {
+    id: "title",
+    label: "Subject",
+    type: "text",
+  },
+  {
+    id: "senderEmail",
+    label: "Email",
+    type: "email",
+  },
+  {
+    id: "message",
+    label: "Message",
+    rows: 5,
+    type: "textarea",
+  },
+];
+
+const getEmailConfig = () => ({
+  serviceID: process.env.REACT_APP_EMAILJS_SERVICE_ID,
+  templateID: process.env.REACT_APP_EMAILJS_TEMPLATE_ID,
+  publicKey:
+    process.env.REACT_APP_EMAILJS_PUBLIC_KEY ||
+    process.env.REACT_APP_EMAILJS_USER_ID,
+});
+
 const ContactForm = () => {
-  const [formData, setFormData] = useState({
-    first_name: "",
-    title: "",
-    senderEmail: "",
-    message: "",
-  });
+  const [formData, setFormData] = useState(initialFormData);
 
   const [errors, setErrors] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -18,7 +54,8 @@ const ContactForm = () => {
 
   const handleChange = (e) => {
     const { name, value } = e.target;
-    setFormData({ ...formData, [name]: value });
+    setFormData((currentFormData) => ({ ...currentFormData, [name]: value }));
+    setErrors((currentErrors) => ({ ...currentErrors, [name]: "" }));
     setFeedbackMessage("");
     setFeedbackType("");
   };
@@ -30,7 +67,7 @@ const ContactForm = () => {
     if (!formData.title.trim()) errors.title = "Title is required";
     if (!formData.senderEmail.trim()) {
       errors.senderEmail = "Email is required";
-    } else if (!/\S+@\S+\.\S+/.test(formData.senderEmail)) {
+    } else if (!emailPattern.test(formData.senderEmail)) {
       errors.senderEmail = "Email address is invalid";
     }
     if (!formData.message.trim()) errors.message = "Message is required";
@@ -38,25 +75,19 @@ const ContactForm = () => {
     return errors;
   };
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    const validationErrors = validate(formData);
+    const validationErrors = validate();
     setErrors(validationErrors);
     setFeedbackMessage("");
     setFeedbackType("");
 
-    if (Object.keys(validationErrors).length === 0) {
-      setIsSubmitting(true);
-      sendEmail();
+    if (Object.keys(validationErrors).length > 0) {
+      return;
     }
-  };
 
-  const sendEmail = async () => {
-    const serviceID = process.env.REACT_APP_EMAILJS_SERVICE_ID;
-    const templateID = process.env.REACT_APP_EMAILJS_TEMPLATE_ID;
-    const publicKey =
-      process.env.REACT_APP_EMAILJS_PUBLIC_KEY ||
-      process.env.REACT_APP_EMAILJS_USER_ID;
+    setIsSubmitting(true);
+    const { serviceID, templateID, publicKey } = getEmailConfig();
 
     if (!serviceID || !templateID || !publicKey) {
       setIsSubmitting(false);
@@ -79,12 +110,7 @@ const ContactForm = () => {
       await emailjs.send(serviceID, templateID, templateParams, publicKey);
       setFeedbackType("success");
       setFeedbackMessage("Your message has been sent successfully.");
-      setFormData({
-        first_name: "",
-        title: "",
-        senderEmail: "",
-        message: "",
-      });
+      setFormData(initialFormData);
     } catch (error) {
       console.error("EmailJS send failed:", error);
       const errorText = String(error?.text || error?.message || "");
@@ -109,88 +135,29 @@ const ContactForm = () => {
           signal, include the product area, stack and what kind of QA support
           you are looking for.
         </p>
-        <div className="contact-links">
-          <a
-            href="https://www.linkedin.com/in/rafa%C5%82-ciesielski-820309100/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Open LinkedIn"
-            title="Open LinkedIn"
-            className="icon linkedin"
-          >
-            <FaLinkedin size={30} />
-          </a>
-          <a
-            href="https://github.com/rciesielski3"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Open GitHub"
-            title="Open GitHub"
-            className="icon github"
-          >
-            <FaGithub size={30} />
-          </a>
-        </div>
+        <SocialLinks className="contact-links" />
       </section>
 
       <form id="contact-form" className="contact-form" onSubmit={handleSubmit}>
-        <div className="form-group">
-          <label htmlFor="first_name">Name</label>
-          <input
-            type="text"
-            id="first_name"
-            name="first_name"
-            value={formData.first_name}
-            onChange={handleChange}
-            className={errors.first_name ? "input-error" : ""}
-          />
-          {errors.first_name && (
-            <span className="form-error">{errors.first_name}</span>
-          )}
-        </div>
+        {formFields.map(({ id, label, rows, type }) => {
+          const Field = type === "textarea" ? "textarea" : "input";
 
-        <div className="form-group">
-          <label htmlFor="title">Subject</label>
-          <input
-            type="text"
-            id="title"
-            name="title"
-            value={formData.title}
-            onChange={handleChange}
-            className={errors.title ? "input-error" : ""}
-          />
-          {errors.title && <span className="form-error">{errors.title}</span>}
-        </div>
-
-        <div className="form-group">
-          <label htmlFor="senderEmail">Email</label>
-          <input
-            type="email"
-            id="senderEmail"
-            name="senderEmail"
-            value={formData.senderEmail}
-            onChange={handleChange}
-            className={errors.senderEmail ? "input-error" : ""}
-          />
-          {errors.senderEmail && (
-            <span className="form-error">{errors.senderEmail}</span>
-          )}
-        </div>
-
-        <div className="form-group">
-          <label htmlFor="message">Message</label>
-          <textarea
-            id="message"
-            name="message"
-            rows="5"
-            value={formData.message}
-            onChange={handleChange}
-            className={errors.message ? "input-error" : ""}
-          ></textarea>
-          {errors.message && (
-            <span className="form-error">{errors.message}</span>
-          )}
-        </div>
+          return (
+            <div className="form-group" key={id}>
+              <label htmlFor={id}>{label}</label>
+              <Field
+                type={type === "textarea" ? undefined : type}
+                id={id}
+                name={id}
+                rows={rows}
+                value={formData[id]}
+                onChange={handleChange}
+                className={errors[id] ? "input-error" : ""}
+              />
+              {errors[id] && <span className="form-error">{errors[id]}</span>}
+            </div>
+          );
+        })}
 
         <button type="submit" disabled={isSubmitting}>
           {isSubmitting ? "Sending..." : "Send Message"}

--- a/src/features/experience/ExperiencePage.jsx
+++ b/src/features/experience/ExperiencePage.jsx
@@ -4,6 +4,7 @@ import { FaSuitcase, FaGraduationCap } from "react-icons/fa";
 import "aos/dist/aos.css";
 
 import { DataContext } from "../../context/DataContext";
+import { profile } from "../../config/profile";
 import "./ExperiencePage.css";
 
 const ExperiencePage = () => {
@@ -128,12 +129,7 @@ const ExperiencePage = () => {
         </p>
         <button
           data-aos="fade-up"
-          onClick={() =>
-            window.open(
-              "https://www.linkedin.com/in/rafa%C5%82-ciesielski-820309100",
-              "_blank"
-            )
-          }
+          onClick={() => window.open(profile.links.linkedin, "_blank")}
         >
           Open LinkedIn
         </button>

--- a/src/features/mainPage/MainPage.jsx
+++ b/src/features/mainPage/MainPage.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { FaArrowRight, FaEnvelope, FaGithub, FaLinkedin } from "react-icons/fa";
+import { FaArrowRight, FaEnvelope } from "react-icons/fa";
 import { Link } from "react-router-dom";
 
 import { doc, getDoc, increment, setDoc } from "firebase/firestore";
@@ -7,8 +7,25 @@ import { logEvent } from "firebase/analytics";
 import { db, analytics } from "../../firebase";
 
 import TypingEffect from "../../components/typing/TypingEffect";
+import { profile } from "../../config/profile";
+import SocialLinks from "../../shared/SocialLinks";
 
 import "./MainPage.css";
+
+const careerSnapshot = [
+  {
+    label: "10+ years",
+    value: "IT, QA and product quality",
+  },
+  {
+    label: "Automation focus",
+    value: "Web, mobile, API and contract testing",
+  },
+  {
+    label: "Product builder",
+    value: "E-commerce, logistics and IoT domains",
+  },
+];
 
 const MainPage = () => {
   const [visitCount, setVisitCount] = React.useState(0);
@@ -39,26 +56,20 @@ const MainPage = () => {
     <div className="main-page">
       <div className="content-wrapper">
         <div className="left-section">
-          <div className="hero-kicker">Quality Engineering Specialist</div>
-          <h1 className="hero-name">Rafal Ciesielski</h1>
+          <div className="hero-kicker">{profile.heroRole}</div>
+          <h1 className="hero-name">{profile.name}</h1>
           <TypingEffect />
           <p className="hero-copy">
             I help teams ship safer products with practical quality strategy,
             reliable automation and product-minded engineering.
           </p>
           <dl className="career-snapshot" aria-label="Career snapshot">
-            <div>
-              <dt>10+ years</dt>
-              <dd>IT, QA and product quality</dd>
-            </div>
-            <div>
-              <dt>Automation focus</dt>
-              <dd>Web, mobile, API and contract testing</dd>
-            </div>
-            <div>
-              <dt>Product builder</dt>
-              <dd>E-commerce, logistics and IoT domains</dd>
-            </div>
+            {careerSnapshot.map((item) => (
+              <div key={item.label}>
+                <dt>{item.label}</dt>
+                <dd>{item.value}</dd>
+              </div>
+            ))}
           </dl>
           <div className="hero-actions">
             <Link to="/experience" className="primary-action">
@@ -74,38 +85,19 @@ const MainPage = () => {
           <div className="profile-card">
             <img
               src={`${process.env.PUBLIC_URL}/images/myImage.webp`}
-              alt="Rafal Ciesielski"
+              alt={profile.name}
               className="profile-image"
             />
             <div className="profile-panel">
               <span>Current focus</span>
-              <p>Quality engineering, automation and product delivery.</p>
+              <p>{profile.currentFocus}</p>
             </div>
           </div>
         </div>
       </div>
 
       <div className="bottom-section">
-        <div className="social-icons">
-          <a
-            href="https://www.linkedin.com/in/rafa%C5%82-ciesielski-820309100/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Open LinkedIn profile"
-            className="icon linkedin"
-          >
-            <FaLinkedin size={30} />
-          </a>
-          <a
-            href="https://github.com/rciesielski3"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Open GitHub profile"
-            className="icon github"
-          >
-            <FaGithub size={30} />
-          </a>
-        </div>
+        <SocialLinks />
 
         <div className="visit-counter-container">
           <p className="visit-counter">

--- a/src/features/skills/Skills.css
+++ b/src/features/skills/Skills.css
@@ -274,7 +274,7 @@
   color: #aab6c7;
   font-size: 0.86rem;
   font-weight: 800;
-  padding: 8px 11px;
+  padding: 6px;
   transition:
     border-color 0.2s ease,
     color 0.2s ease,

--- a/src/shared/SocialLinks.jsx
+++ b/src/shared/SocialLinks.jsx
@@ -1,0 +1,40 @@
+import { FaGithub, FaLinkedin } from "react-icons/fa";
+
+import { profile } from "../config/profile";
+
+const socialLinks = [
+  {
+    ariaLabel: "Open LinkedIn profile",
+    className: "linkedin",
+    href: profile.links.linkedin,
+    Icon: FaLinkedin,
+    title: "Open LinkedIn",
+  },
+  {
+    ariaLabel: "Open GitHub profile",
+    className: "github",
+    href: profile.links.github,
+    Icon: FaGithub,
+    title: "Open GitHub",
+  },
+];
+
+const SocialLinks = ({ className = "social-icons" }) => (
+  <div className={className}>
+    {socialLinks.map(({ ariaLabel, className, href, Icon, title }) => (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={ariaLabel}
+        className={`icon ${className}`}
+        title={title}
+        key={href}
+      >
+        <Icon size={30} />
+      </a>
+    ))}
+  </div>
+);
+
+export default SocialLinks;

--- a/src/shared/navbar/NavBar.css
+++ b/src/shared/navbar/NavBar.css
@@ -76,6 +76,14 @@
   background: transparent;
   border: 0;
   border-radius: 0;
+  clip-path: polygon(
+    0 0,
+    calc(100% - var(--nav-corner-cut)) 0,
+    100% var(--nav-corner-cut),
+    100% 100%,
+    var(--nav-corner-cut) 100%,
+    0 calc(100% - var(--nav-corner-cut))
+  );
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -87,34 +95,30 @@
   font-weight: 800;
   color: #cbd5e1;
   transition:
-    border-color 0.2s ease,
-    background 0.2s ease,
     color 0.2s ease,
     transform 0.2s ease;
 }
 
 .navbar-menu-item a::before {
-  background: rgba(2, 6, 23, 0.94);
-  clip-path: inherit;
+  --nav-border-color: rgba(54, 241, 205, 0.48);
+  background:
+    linear-gradient(var(--nav-border-color), var(--nav-border-color)) left top / calc(100% - var(--nav-corner-cut)) 1px no-repeat,
+    linear-gradient(var(--nav-border-color), var(--nav-border-color)) right var(--nav-corner-cut) / 1px calc(100% - var(--nav-corner-cut)) no-repeat,
+    linear-gradient(var(--nav-border-color), var(--nav-border-color)) var(--nav-corner-cut) bottom / calc(100% - var(--nav-corner-cut)) 1px no-repeat,
+    linear-gradient(var(--nav-border-color), var(--nav-border-color)) left top / 1px calc(100% - var(--nav-corner-cut)) no-repeat,
+    linear-gradient(45deg, transparent calc(50% - 0.75px), var(--nav-border-color) calc(50% - 0.75px), var(--nav-border-color) calc(50% + 0.75px), transparent calc(50% + 0.75px)) right top / var(--nav-corner-cut) var(--nav-corner-cut) no-repeat,
+    linear-gradient(45deg, transparent calc(50% - 0.75px), var(--nav-border-color) calc(50% - 0.75px), var(--nav-border-color) calc(50% + 0.75px), transparent calc(50% + 0.75px)) left bottom / var(--nav-corner-cut) var(--nav-corner-cut) no-repeat;
   content: "";
-  inset: 1px;
+  inset: 0;
   opacity: 0;
   position: absolute;
-  transition: opacity 0.2s ease;
+  pointer-events: none;
+  transition: opacity 0.18s ease;
   z-index: -1;
 }
 
 .navbar-menu-item a:hover,
 .navbar-menu-item a.active {
-  background: rgba(54, 241, 205, 0.22);
-  clip-path: polygon(
-    0 0,
-    calc(100% - var(--nav-corner-cut)) 0,
-    100% var(--nav-corner-cut),
-    100% 100%,
-    var(--nav-corner-cut) 100%,
-    0 calc(100% - var(--nav-corner-cut))
-  );
   color: #7cf7dc;
 }
 

--- a/src/shared/navbar/Navbar.jsx
+++ b/src/shared/navbar/Navbar.jsx
@@ -2,25 +2,25 @@ import React from "react";
 import { NavLink } from "react-router-dom";
 import { FaBars, FaTimes } from "react-icons/fa";
 
+import { navigationItems, profile } from "../../config/profile";
 import "./NavBar.css";
+
+const BrandLink = ({ className = "", onClick }) => (
+  <NavLink to="/" className={`navbar-title ${className}`} onClick={onClick}>
+    RC<span>{profile.brand}</span>
+  </NavLink>
+);
 
 const NavBar = () => {
   const [menuOpen, setMenuOpen] = React.useState(false);
 
-  const toggleMenu = () => {
-    setMenuOpen(!menuOpen);
-  };
+  const closeMenu = () => setMenuOpen(false);
+  const toggleMenu = () => setMenuOpen((isOpen) => !isOpen);
 
   return (
     <nav className="navbar">
       <div className="navbar-toggle">
-        <NavLink
-          to="/"
-          className="navbar-title"
-          onClick={() => setMenuOpen(false)}
-        >
-          RC<span>Quality Engineering</span>
-        </NavLink>
+        <BrandLink onClick={closeMenu} />
         <button
           onClick={toggleMenu}
           className="navbar-menu-btn"
@@ -32,44 +32,15 @@ const NavBar = () => {
           {menuOpen ? <FaTimes /> : <FaBars />}
         </button>
       </div>
-      <NavLink
-        to="/"
-        className="navbar-title navbar-title-desktop"
-        onClick={() => setMenuOpen(false)}
-      >
-        RC<span>Quality Engineering</span>
-      </NavLink>
+      <BrandLink className="navbar-title-desktop" onClick={closeMenu} />
       <ul className={`navbar-menu ${menuOpen ? "active" : ""}`}>
-        <li className="navbar-menu-item">
-          <NavLink to="/" onClick={() => setMenuOpen(false)}>
-            Home
-          </NavLink>
-        </li>
-        <li className="navbar-menu-item">
-          <NavLink to="/experience" onClick={() => setMenuOpen(false)}>
-            Experience
-          </NavLink>
-        </li>
-        <li className="navbar-menu-item">
-          <NavLink to="/skills" onClick={() => setMenuOpen(false)}>
-            Skills
-          </NavLink>
-        </li>
-        <li className="navbar-menu-item">
-          <NavLink to="/courses" onClick={() => setMenuOpen(false)}>
-            Certifications
-          </NavLink>
-        </li>
-        <li className="navbar-menu-item">
-          <NavLink to="/github" onClick={() => setMenuOpen(false)}>
-            GitHub
-          </NavLink>
-        </li>
-        <li className="navbar-menu-item">
-          <NavLink to="/contact" onClick={() => setMenuOpen(false)}>
-            Contact
-          </NavLink>
-        </li>
+        {navigationItems.map((item) => (
+          <li className="navbar-menu-item" key={item.path}>
+            <NavLink to={item.path} onClick={closeMenu}>
+              {item.label}
+            </NavLink>
+          </li>
+        ))}
       </ul>
     </nav>
   );


### PR DESCRIPTION
## Summary
- Centralize reusable portfolio metadata and navigation items in `src/config/profile.js`.
- Add shared `SocialLinks` component and reuse it on the main and contact pages.
- Simplify contact form rendering with field definitions while keeping EmailJS behavior intact.
- Polish the InPost experience copy and keep the radar chip spacing compact.
- Fix navigation hover/active clipped-border rendering without a background-color flash.
