### PR TITLE
Feat/05 language foundation

### DIFF
--- a/public/data/experiences.json
+++ b/public/data/experiences.json
@@ -58,13 +58,11 @@
   "education": [
     {
       "title": "Master of Science in Electrical Engineering",
-      "studies": "Poznan University of Technology",
-      "time": "2007 - 2009"
+      "studies": "Poznan University of Technology"
     },
     {
       "title": "Bachelor of Electrical Engineering",
-      "studies": "Poznan University of Technology",
-      "time": "2002 - 2006"
+      "studies": "Poznan University of Technology"
     }
   ]
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import ExperiencePage from "./features/experience/ExperiencePage";
 import NotFound from "./features/notFound/NotFound";
 
 import DataProvider from "./context/DataContext";
+import { LanguageProvider } from "./context/LanguageContext";
 import NavBar from "./shared/navbar/Navbar";
 import Footer from "./shared/Footer";
 import "./App.css";
@@ -18,25 +19,27 @@ import "./App.css";
 const App = () => {
   return (
     <DataProvider>
-      <Router>
-        <div className="app-layout">
-          <NavBar />
-          <div className="app-main">
-            <Routes>
-              <Route path="/" element={<MainPage />} />
-              <Route path="/skills" element={<Skills />} />
-              <Route path="/courses" element={<Certifications />} />
-              <Route path="/github" element={<GithubRepositories />} />
-              <Route path="/experience" element={<ExperiencePage />} />
-              <Route path="/contact" element={<ContactForm />} />
-              <Route path="/privacy-policy" element={<PrivacyPolicy />} />
-              <Route path="/portfolio" element={<MainPage />} />
-              <Route path="*" element={<NotFound />} />
-            </Routes>
+      <LanguageProvider>
+        <Router>
+          <div className="app-layout">
+            <NavBar />
+            <div className="app-main">
+              <Routes>
+                <Route path="/" element={<MainPage />} />
+                <Route path="/skills" element={<Skills />} />
+                <Route path="/courses" element={<Certifications />} />
+                <Route path="/github" element={<GithubRepositories />} />
+                <Route path="/experience" element={<ExperiencePage />} />
+                <Route path="/contact" element={<ContactForm />} />
+                <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+                <Route path="/portfolio" element={<MainPage />} />
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </div>
+            <Footer />
           </div>
-          <Footer />
-        </div>
-      </Router>
+        </Router>
+      </LanguageProvider>
     </DataProvider>
   );
 };

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import { render, screen } from "@testing-library/react";
+import App from "./App";
 
-test('renders learn react link', () => {
+test("renders the portfolio home page", () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getByRole("heading", { name: /rafal ciesielski/i })).toBeInTheDocument();
+  expect(screen.getAllByText(/quality engineering/i)[0]).toBeInTheDocument();
 });

--- a/src/components/typing/TypingEffect.jsx
+++ b/src/components/typing/TypingEffect.jsx
@@ -3,18 +3,25 @@ import "./TypingEffect.css";
 
 import { DataContext } from "../../context/DataContext";
 
-const TypingEffect = () => {
+const TypingEffect = ({ staticText = "I'm", words = [] }) => {
   const [currentWord, setCurrentWord] = useState("");
   const [isDeleting, setIsDeleting] = useState(false);
   const [loopIndex, setLoopIndex] = useState(0);
   const [typingSpeed, setTypingSpeed] = useState(150);
   const { iAm } = useContext(DataContext);
-  const staticText = "I'm";
+  const typingWords = words.length > 0 ? words : iAm;
 
   React.useEffect(() => {
-    if (iAm.length === 0) return;
+    setCurrentWord("");
+    setIsDeleting(false);
+    setLoopIndex(0);
+    setTypingSpeed(150);
+  }, [words]);
 
-    const fullWord = iAm[loopIndex % iAm.length];
+  React.useEffect(() => {
+    if (typingWords.length === 0) return;
+
+    const fullWord = typingWords[loopIndex % typingWords.length];
 
     const updateWord = () => {
       setCurrentWord((prev) =>
@@ -35,7 +42,7 @@ const TypingEffect = () => {
 
     const timeout = setTimeout(updateWord, typingSpeed);
     return () => clearTimeout(timeout);
-  }, [currentWord, isDeleting, loopIndex, typingSpeed, iAm]);
+  }, [currentWord, isDeleting, loopIndex, typingSpeed, typingWords]);
 
   return (
     <div className="typing-text">

--- a/src/config/profile.js
+++ b/src/config/profile.js
@@ -1,8 +1,5 @@
 export const profile = {
   name: "Rafal Ciesielski",
-  brand: "Quality Engineering",
-  heroRole: "Quality Engineering Specialist",
-  currentFocus: "Quality engineering, automation and product delivery.",
   links: {
     github: "https://github.com/rciesielski3",
     linkedin: "https://www.linkedin.com/in/rafa%C5%82-ciesielski-820309100/",
@@ -10,10 +7,10 @@ export const profile = {
 };
 
 export const navigationItems = [
-  { label: "Home", path: "/" },
-  { label: "Experience", path: "/experience" },
-  { label: "Skills", path: "/skills" },
-  { label: "Certifications", path: "/courses" },
-  { label: "GitHub", path: "/github" },
-  { label: "Contact", path: "/contact" },
+  { key: "home", path: "/" },
+  { key: "experience", path: "/experience" },
+  { key: "skills", path: "/skills" },
+  { key: "certifications", path: "/courses" },
+  { key: "github", path: "/github" },
+  { key: "contact", path: "/contact" },
 ];

--- a/src/content/portfolioContent.js
+++ b/src/content/portfolioContent.js
@@ -47,6 +47,7 @@ export const portfolioContent = {
           value: "E-commerce, logistics and IoT domains",
         },
       ],
+      careerSnapshotLabel: "Career snapshot",
       actions: {
         experience: "View Experience",
         contact: "Contact",
@@ -81,6 +82,7 @@ export const portfolioContent = {
             "Playwright, WebdriverIO, API, CI/CD and AI-assisted workflows.",
         },
       ],
+      summaryLabel: "Experience summary",
       sections: {
         experience: "Experience",
         education: "Education",
@@ -117,7 +119,9 @@ export const portfolioContent = {
           description: "Clear feedback for teams, stakeholders and releases.",
         },
       ],
+      summaryLabel: "Skills summary",
       bridge: {
+        ariaLabel: "Capability context",
         kicker: "How it shows up",
         title: "From release risk to practical execution",
         description:
@@ -158,6 +162,7 @@ export const portfolioContent = {
           ],
         },
       ],
+      capabilitiesLabel: "Core capabilities",
       stack: {
         kicker: "Tech stack",
         title: "Tools I can discuss with context",
@@ -391,6 +396,7 @@ export const portfolioContent = {
           value: "E-commerce, logistyka i IoT",
         },
       ],
+      careerSnapshotLabel: "Podsumowanie kariery",
       actions: {
         experience: "Zobacz doświadczenie",
         contact: "Kontakt",
@@ -424,6 +430,7 @@ export const portfolioContent = {
             "Playwright, WebdriverIO, API, CI/CD i przepływy pracy wspierane AI.",
         },
       ],
+      summaryLabel: "Podsumowanie doświadczenia",
       sections: {
         experience: "Doświadczenie",
         education: "Edukacja",
@@ -530,7 +537,9 @@ export const portfolioContent = {
             "Czytelna informacja zwrotna dla zespołów, interesariuszy i wydań.",
         },
       ],
+      summaryLabel: "Podsumowanie kompetencji",
       bridge: {
+        ariaLabel: "Kontekst kompetencji",
         kicker: "Jak to działa",
         title: "Od ryzyka wydania do praktycznej realizacji",
         description:
@@ -571,6 +580,7 @@ export const portfolioContent = {
           ],
         },
       ],
+      capabilitiesLabel: "Główne kompetencje",
       stack: {
         kicker: "Stack technologiczny",
         title: "Narzędzia, o których mogę rozmawiać z kontekstem",

--- a/src/content/portfolioContent.js
+++ b/src/content/portfolioContent.js
@@ -18,6 +18,8 @@ export const portfolioContent = {
       certifications: "Certifications",
       github: "GitHub",
       contact: "Contact",
+      closeMenu: "Close navigation menu",
+      openMenu: "Open navigation menu",
     },
     home: {
       typing: {
@@ -230,6 +232,65 @@ export const portfolioContent = {
         ],
       },
     },
+    certifications: {
+      hero: {
+        kicker: "Continuous learning",
+        title: "Certifications",
+        description:
+          "A curated training record across test automation, AI, accessibility, performance, web development and networking foundations.",
+      },
+    },
+    github: {
+      hero: {
+        kicker: "Build log",
+        title: "GitHub repositories",
+        description:
+          "Projects, experiments and learning repos that show how I approach automation, frontend foundations and practical engineering.",
+      },
+      emptyState: "Coming soon. Under construction.",
+      errorPrefix: "Error",
+      card: {
+        openLabelPrefix: "Open",
+        openLabelSuffix: "on GitHub",
+        fallbackDescription: "No description provided yet.",
+        viewRepository: "View repository",
+      },
+      externalWork: {
+        kicker: "Supporting work",
+        title: "Articles and side projects",
+        description:
+          "These are useful as secondary proof points, so they live here rather than competing with the primary portfolio navigation.",
+        items: [
+          {
+            title: "QA Journey",
+            description: "Writing and notes around quality assurance practice.",
+            url: "https://qa-journey.blogspot.com/",
+          },
+          {
+            title: "Quality Assurance Blog",
+            description: "Additional QA articles and experiments.",
+            url: "https://qa-blog.onrender.com/",
+          },
+          {
+            title: "JS & React Fundamentals",
+            description:
+              "Learning lab for JavaScript, React and Next.js fundamentals.",
+            url: "https://learn-js-react-basics.vercel.app/",
+          },
+          {
+            title: "Mini Game Collection",
+            description:
+              "Small frontend projects focused on interaction and polish.",
+            url: "https://mini-game-collection.vercel.app/",
+          },
+          {
+            title: "My Smart Home",
+            description: "Smart home related page and domain project.",
+            url: "https://mysmarthome.cba.pl/",
+          },
+        ],
+      },
+    },
     contact: {
       kicker: "Contact",
       title: "Let's talk quality, automation or product delivery.",
@@ -270,6 +331,16 @@ export const portfolioContent = {
         experience: "Experience",
       },
     },
+    social: {
+      githubAria: "Open GitHub profile",
+      githubTitle: "Open GitHub",
+      linkedinAria: "Open LinkedIn profile",
+      linkedinTitle: "Open LinkedIn",
+    },
+    common: {
+      loading: "Loading...",
+      close: "Close",
+    },
   },
   pl: {
     languageName: "Polski",
@@ -286,6 +357,8 @@ export const portfolioContent = {
       certifications: "Certyfikaty",
       github: "GitHub",
       contact: "Kontakt",
+      closeMenu: "Zamknij menu nawigacji",
+      openMenu: "Otwórz menu nawigacji",
     },
     home: {
       typing: {
@@ -366,41 +439,49 @@ export const portfolioContent = {
           },
           {
             title: "Starszy inżynier QA",
+            time: "wrz 2025 – obecnie",
             description:
               "Buduję i utrzymuję automatyczne pokrycie jakościowe dla warstw web, mobile, backend, kontraktów i wydajności. Pracuję z Playwrightem w TypeScript, WebdriverIO dla aplikacji natywnych, kotlinowymi frameworkami testów backendowych oraz testami wydajnościowymi Gatling. Dostarczam raporty jakości, dokumentację i czytelną analizę defektów wspierającą decyzje o wydaniu.",
           },
           {
             title: "Ekspert ds. testów",
+            time: "maj 2025 – wrz 2025",
             description:
               "Odpowiadałem za pokrycie testami funkcjonalnymi, regresyjnymi, walidacyjnymi i WCAG dla aplikacji bankowych na mobile i desktop. Przekładałem user stories na scenariusze testowe, raportowałem defekty w Jira/Xray i wspierałem pewność wydań.",
           },
           {
             title: "Tester oprogramowania",
+            time: "gru 2023 – mar 2025",
             description:
               "Realizowałem testy integracyjne, funkcjonalne, regresyjne i walidację danych dla przepływów iOS oraz Android. Budowałem automatyczne sprawdzenia i dokumentację użytkownika, żeby ograniczać tarcie we wsparciu i poprawiać niezawodność produktu.",
           },
           {
-            title: "Full-stack developer — praktyka",
+            title: "Programista full-stack — praktyka",
+            time: "paź 2023 – maj 2025",
             description:
-              "Budowałem i testowałem platformę e-learningową z użyciem React, Next.js, Node.js i NestJS. Ćwiczyłem code review, poprawę niezawodności i produktowe myślenie end-to-end z perspektywy developera oraz QA.",
+              "Budowałem i testowałem platformę e-learningową z użyciem React, Next.js, Node.js i NestJS. Ćwiczyłem przegląd kodu, poprawę niezawodności i produktowe myślenie end-to-end z perspektywy programisty oraz QA.",
           },
           {
             title: "Koordynator QA",
+            time: "gru 2020 – gru 2023",
             description:
-              "Koordynowałem prace mobile QA, odpowiadałem za cykl życia przypadków testowych w TestRail i śledziłem delivery w Jira. Wspierałem estymacje, planowanie i usprawnienia procesu, żeby jakość była widoczna w trakcie wydań.",
+              "Koordynowałem prace mobile QA, odpowiadałem za cykl życia przypadków testowych w TestRail i śledziłem dostarczanie zadań w Jira. Wspierałem estymacje, planowanie i usprawnienia procesu, żeby jakość była widoczna w trakcie wydań.",
           },
           {
             title: "Inżynier QA",
+            time: "maj 2018 – gru 2020",
             description:
               "Walidowałem aplikacje mobile i web przez testy eksploracyjne, regresyjne i automatyczne z użyciem Detox oraz Cypress. Utrzymywałem pokrycie w TestRail i pomagałem usprawniać powtarzalne sprawdzenia przed wydaniem.",
           },
           {
             title: "Inżynier wsparcia technicznego",
+            time: "wrz 2015 – maj 2018",
             description:
               "Wspierałem użytkowników systemów inteligentnego domu i przekładałem powtarzalne problemy na czytelne zgłoszenia defektów. Utrzymywałem dokumentację w Confluence, obsługiwałem zgłoszenia w Desk.com i łączyłem informacje zwrotne od klientów z zespołami produktowymi.",
           },
           {
             title: "Młodszy inżynier systemów IT",
+            time: "wrz 2013 – wrz 2015",
             description:
               "Zapewniałem wsparcie IT dla wewnętrznych zespołów inżynieryjnych, w tym konfigurację sprzętu i oprogramowania oraz obsługę zgłoszeń w narzędziach ITSM. Zbudowałem fundament w obszarze infrastruktury, operacji wsparcia i jakości usług.",
           },
@@ -422,7 +503,7 @@ export const portfolioContent = {
         kicker: "Mapa kompetencji",
         title: "Kompetencje wokół stabilnych wydań",
         description:
-          "Praktyczny zestaw kompetencji QA obejmujący automatyzację, analizę ryzyka i współpracę z zespołami delivery. Mniej buzzwordów, więcej sygnałów pomagających dowozić z pewnością.",
+          "Praktyczny zestaw kompetencji QA obejmujący automatyzację, analizę ryzyka i współpracę z zespołami odpowiedzialnymi za dostarczanie produktu. Mniej buzzwordów, więcej sygnałów pomagających dowozić z pewnością.",
       },
       summary: [
         {
@@ -478,7 +559,7 @@ export const portfolioContent = {
           points: [
             "Współpraca z developerami, interesariuszami i zespołami wsparcia",
             "Code review z perspektywy jakości",
-            "Wsparcie pracy agile, dokumentacji i rozwiązywania problemów",
+            "Wsparcie zwinnej pracy zespołu, dokumentacji i rozwiązywania problemów",
           ],
         },
       ],
@@ -558,9 +639,68 @@ export const portfolioContent = {
         ],
       },
     },
+    certifications: {
+      hero: {
+        kicker: "Ciągły rozwój",
+        title: "Certyfikaty",
+        description:
+          "Wybrane szkolenia z obszaru automatyzacji testów, AI, dostępności, wydajności, web developmentu i podstaw sieci.",
+      },
+    },
+    github: {
+      hero: {
+        kicker: "Dziennik pracy",
+        title: "Repozytoria GitHub",
+        description:
+          "Projekty, eksperymenty i repozytoria edukacyjne pokazujące moje podejście do automatyzacji, podstaw frontendu i praktycznej inżynierii.",
+      },
+      emptyState: "Wkrótce. Sekcja w przygotowaniu.",
+      errorPrefix: "Błąd",
+      card: {
+        openLabelPrefix: "Otwórz",
+        openLabelSuffix: "na GitHubie",
+        fallbackDescription: "Brak opisu repozytorium.",
+        viewRepository: "Zobacz repozytorium",
+      },
+      externalWork: {
+        kicker: "Dodatkowe materiały",
+        title: "Artykuły i projekty poboczne",
+        description:
+          "To dodatkowe punkty potwierdzające praktykę, dlatego są tutaj, a nie w głównej nawigacji portfolio.",
+        items: [
+          {
+            title: "QA Journey",
+            description: "Notatki i teksty o praktyce zapewniania jakości.",
+            url: "https://qa-journey.blogspot.com/",
+          },
+          {
+            title: "Quality Assurance Blog",
+            description: "Dodatkowe artykuły i eksperymenty QA.",
+            url: "https://qa-blog.onrender.com/",
+          },
+          {
+            title: "JS & React Fundamentals",
+            description:
+              "Laboratorium nauki podstaw JavaScript, React i Next.js.",
+            url: "https://learn-js-react-basics.vercel.app/",
+          },
+          {
+            title: "Mini Game Collection",
+            description:
+              "Małe projekty frontendowe skupione na interakcji i dopracowaniu UI.",
+            url: "https://mini-game-collection.vercel.app/",
+          },
+          {
+            title: "My Smart Home",
+            description: "Strona i projekt domenowy związany ze smart home.",
+            url: "https://mysmarthome.cba.pl/",
+          },
+        ],
+      },
+    },
     contact: {
       kicker: "Kontakt",
-      title: "Porozmawiajmy o jakości, automatyzacji albo delivery produktu.",
+      title: "Porozmawiajmy o jakości, automatyzacji albo dostarczaniu produktu.",
       description:
         "Napisz krótko, a wrócę z konkretnym kontekstem. Najszybciej zadziała informacja o obszarze produktu, stacku i rodzaju wsparcia QA, którego szukasz.",
       form: {
@@ -597,6 +737,16 @@ export const portfolioContent = {
         home: "Start",
         experience: "Doświadczenie",
       },
+    },
+    social: {
+      githubAria: "Otwórz profil GitHub",
+      githubTitle: "Otwórz GitHub",
+      linkedinAria: "Otwórz profil LinkedIn",
+      linkedinTitle: "Otwórz LinkedIn",
+    },
+    common: {
+      loading: "Ładowanie...",
+      close: "Zamknij",
     },
   },
 };

--- a/src/content/portfolioContent.js
+++ b/src/content/portfolioContent.js
@@ -1,218 +1,542 @@
-export const homeContent = {
-  heroCopy:
-    "I help teams ship safer products with practical quality strategy, reliable automation and product-minded engineering.",
-  careerSnapshot: [
-    {
-      label: "10+ years",
-      value: "IT, QA and product quality",
-    },
-    {
-      label: "Automation focus",
-      value: "Web, mobile, API and contract testing",
-    },
-    {
-      label: "Product builder",
-      value: "E-commerce, logistics and IoT domains",
-    },
-  ],
-  currentFocusLabel: "Current focus",
-  visitorsLabel: "Visitors",
-};
+export const defaultLanguage = "en";
 
-export const experienceContent = {
-  hero: {
-    kicker: "Resume",
-    title: "Experience",
-    description:
-      "A timeline of quality engineering, automation, product delivery and hands-on product building across logistics, banking, web, mobile and smart home domains.",
-  },
-  summary: [
-    {
-      label: "Current scope",
-      title: "Quality engineering",
-      description: "Automation, contracts, APIs, mobile and release feedback.",
-    },
-    {
-      label: "Product ownership",
-      title: "ZabawkowyBox.pl",
-      description: "E-commerce subscriptions, payments, CMS and operations.",
-    },
-    {
-      label: "Technical path",
-      title: "Automation practice",
-      description:
-        "Playwright, WebdriverIO, API, CI/CD and AI-assisted workflows.",
-    },
-  ],
-  sections: {
-    experience: "Experience",
-    education: "Education",
-  },
-  cta: {
-    title: "Connect with Me",
-    description:
-      "If you want to know more about me, feel free to check out my LinkedIn profile.",
-    button: "Open LinkedIn",
-  },
-};
+export const supportedLanguages = ["en", "pl"];
 
-export const skillsContent = {
-  hero: {
-    kicker: "Capability map",
-    title: "Skills built around reliable delivery",
-    description:
-      "A practical QA toolkit across automation, risk analysis and delivery collaboration. Less buzzwords, more signals that help teams ship with confidence.",
-  },
-  summary: [
-    {
-      label: "Strategy",
-      title: "Risk-based QA",
-      description: "Coverage decisions based on product and release risk.",
+export const portfolioContent = {
+  en: {
+    languageName: "English",
+    languageToggleLabel: "Change language",
+    profile: {
+      brand: "Quality Engineering",
+      heroRole: "Quality Engineering Specialist",
+      currentFocus: "Quality engineering, automation and product delivery.",
     },
-    {
-      label: "Automation",
-      title: "Practical coverage",
-      description: "UI, API and mobile checks designed for maintainability.",
+    navigation: {
+      home: "Home",
+      experience: "Experience",
+      skills: "Skills",
+      certifications: "Certifications",
+      github: "GitHub",
+      contact: "Contact",
     },
-    {
-      label: "Delivery",
-      title: "Quality signals",
-      description: "Clear feedback for teams, stakeholders and releases.",
-    },
-  ],
-  bridge: {
-    kicker: "How it shows up",
-    title: "From release risk to practical execution",
-    description:
-      "The summary above is the operating model. The sections below translate it into day-to-day QA ownership: planning, automation, defects, environments, reporting and collaboration.",
-  },
-  capabilities: [
-    {
-      label: "Main responsibilities",
-      title: "Quality delivery ownership",
-      description:
-        "Planning, execution and reporting that help teams understand release readiness.",
-      points: [
-        "Develop and maintain test plans and test cases for mobile and desktop applications",
-        "Execute manual and automated tests to verify requirements",
-        "Analyze test results, monitor quality metrics and report release signals",
+    home: {
+      typing: {
+        staticText: "I'm",
+        words: [
+          "Test Automation Engineer",
+          "AI-assisted Testing Practitioner",
+          "Product-minded QA",
+          "Quality Engineering Specialist",
+        ],
+      },
+      heroCopy:
+        "I help teams ship safer products with practical quality strategy, reliable automation and product-minded engineering.",
+      careerSnapshot: [
+        {
+          label: "10+ years",
+          value: "IT, QA and product quality",
+        },
+        {
+          label: "Automation focus",
+          value: "Web, mobile, API and contract testing",
+        },
+        {
+          label: "Product builder",
+          value: "E-commerce, logistics and IoT domains",
+        },
       ],
+      actions: {
+        experience: "View Experience",
+        contact: "Contact",
+      },
+      currentFocusLabel: "Current focus",
+      visitorsLabel: "Visitors",
     },
-    {
-      label: "Quality operations",
-      title: "Defect, environment and data control",
-      description:
-        "Operational QA practices that keep testing reliable, repeatable and useful.",
-      points: [
-        "Identify, document and track bugs and customer issues",
-        "Create and maintain test environments and test data",
-        "Troubleshoot issues and support root-cause analysis",
+    experience: {
+      hero: {
+        kicker: "Resume",
+        title: "Experience",
+        description:
+          "A timeline of quality engineering, automation, product delivery and hands-on product building across logistics, banking, web, mobile and smart home domains.",
+      },
+      summary: [
+        {
+          label: "Current scope",
+          title: "Quality engineering",
+          description:
+            "Automation, contracts, APIs, mobile and release feedback.",
+        },
+        {
+          label: "Product ownership",
+          title: "ZabawkowyBox.pl",
+          description: "E-commerce subscriptions, payments, CMS and operations.",
+        },
+        {
+          label: "Technical path",
+          title: "Automation practice",
+          description:
+            "Playwright, WebdriverIO, API, CI/CD and AI-assisted workflows.",
+        },
       ],
+      sections: {
+        experience: "Experience",
+        education: "Education",
+      },
+      cta: {
+        title: "Connect with Me",
+        description:
+          "If you want to know more about me, feel free to check out my LinkedIn profile.",
+        button: "Open LinkedIn",
+      },
     },
-    {
-      label: "Skills & competencies",
-      title: "Collaboration and product quality",
-      description:
-        "Cross-functional quality work that supports delivery, feedback and continuous improvement.",
-      points: [
-        "Cross-functional collaboration with developers and stakeholders",
-        "Code review feedback from a quality perspective",
-        "Agile delivery support, documentation and problem solving",
+    skills: {
+      hero: {
+        kicker: "Capability map",
+        title: "Skills built around reliable delivery",
+        description:
+          "A practical QA toolkit across automation, risk analysis and delivery collaboration. Less buzzwords, more signals that help teams ship with confidence.",
+      },
+      summary: [
+        {
+          label: "Strategy",
+          title: "Risk-based QA",
+          description: "Coverage decisions based on product and release risk.",
+        },
+        {
+          label: "Automation",
+          title: "Practical coverage",
+          description: "UI, API and mobile checks designed for maintainability.",
+        },
+        {
+          label: "Delivery",
+          title: "Quality signals",
+          description: "Clear feedback for teams, stakeholders and releases.",
+        },
       ],
+      bridge: {
+        kicker: "How it shows up",
+        title: "From release risk to practical execution",
+        description:
+          "The summary above is the operating model. The sections below translate it into day-to-day QA ownership: planning, automation, defects, environments, reporting and collaboration.",
+      },
+      capabilities: [
+        {
+          label: "Main responsibilities",
+          title: "Quality delivery ownership",
+          description:
+            "Planning, execution and reporting that help teams understand release readiness.",
+          points: [
+            "Develop and maintain test plans and test cases for mobile and desktop applications",
+            "Execute manual and automated tests to verify requirements",
+            "Analyze test results, monitor quality metrics and report release signals",
+          ],
+        },
+        {
+          label: "Quality operations",
+          title: "Defect, environment and data control",
+          description:
+            "Operational QA practices that keep testing reliable, repeatable and useful.",
+          points: [
+            "Identify, document and track bugs and customer issues",
+            "Create and maintain test environments and test data",
+            "Troubleshoot issues and support root-cause analysis",
+          ],
+        },
+        {
+          label: "Skills & competencies",
+          title: "Collaboration and product quality",
+          description:
+            "Cross-functional quality work that supports delivery, feedback and continuous improvement.",
+          points: [
+            "Cross-functional collaboration with developers and stakeholders",
+            "Code review feedback from a quality perspective",
+            "Agile delivery support, documentation and problem solving",
+          ],
+        },
+      ],
+      stack: {
+        kicker: "Tech stack",
+        title: "Tools I can discuss with context",
+        description:
+          "Grouped by where they support quality work, not as a flat inventory.",
+        groups: [
+          {
+            title: "Automation & testing",
+            tools: [
+              "Playwright",
+              "WebdriverIO",
+              "Appium",
+              "Postman",
+              "SoapUI",
+              "Gatling",
+              "Cucumber",
+              "REST API testing",
+              "SOAP API testing",
+              "Contract testing",
+              "WCAG",
+              "Cypress",
+              "Detox",
+              "K6",
+            ],
+          },
+          {
+            title: "QA operations",
+            tools: [
+              "Jira",
+              "Xray",
+              "TestRail",
+              "Confluence",
+              "CI/CD quality gates",
+              "GitHub Actions",
+              "Quality reports",
+            ],
+          },
+          {
+            title: "Development",
+            tools: [
+              "TypeScript",
+              "JavaScript",
+              "Kotlin basics",
+              "Remix",
+              "HTML",
+              "CSS",
+              "React",
+              "Next.js",
+              "Node.js",
+              "Tailwind CSS",
+              "Prisma",
+              "PostgreSQL",
+              "Java",
+            ],
+          },
+          {
+            title: "Platforms, integrations & AI",
+            tools: [
+              "Android testing",
+              "iOS testing",
+              "Git",
+              "Firebase",
+              "Stripe",
+              "InPost API",
+              "Cloudinary",
+              "Resend",
+              "Google Sheets API",
+              "GitHub Copilot",
+              "AI agents",
+              "MCP basics",
+              "AI testing",
+            ],
+          },
+        ],
+      },
     },
-  ],
-  stack: {
-    kicker: "Tech stack",
-    title: "Tools I can discuss with context",
-    description:
-      "Grouped by where they support quality work, not as a flat inventory.",
-    groups: [
-      {
-        title: "Automation & testing",
-        tools: [
-          "Playwright",
-          "WebdriverIO",
-          "Appium",
-          "Postman",
-          "SoapUI",
-          "Gatling",
-          "Cucumber",
-          "REST API testing",
-          "SOAP API testing",
-          "Contract testing",
-          "WCAG",
-          "Cypress",
-          "Detox",
-          "K6",
+    contact: {
+      kicker: "Contact",
+      title: "Let's talk quality, automation or product delivery.",
+      description:
+        "Send a concise note and I will get back with context. For a faster signal, include the product area, stack and what kind of QA support you are looking for.",
+      form: {
+        fields: [
+          { id: "first_name", label: "Name", type: "text" },
+          { id: "title", label: "Subject", type: "text" },
+          { id: "senderEmail", label: "Email", type: "email" },
+          { id: "message", label: "Message", rows: 5, type: "textarea" },
         ],
+        errors: {
+          first_name: "Name is required",
+          title: "Subject is required",
+          senderEmailRequired: "Email is required",
+          senderEmailInvalid: "Email address is invalid",
+          message: "Message is required",
+        },
+        submit: "Send Message",
+        submitting: "Sending...",
+        success: "Your message has been sent successfully.",
+        missingConfig: "Email service is not configured.",
+        invalidPublicKey:
+          "Email service has an invalid public key. Please update the EmailJS configuration.",
+        genericError:
+          "The message could not be sent. Please check the form configuration or try again later.",
       },
-      {
-        title: "QA operations",
-        tools: [
-          "Jira",
-          "Xray",
-          "TestRail",
-          "Confluence",
-          "CI/CD quality gates",
-          "GitHub Actions",
-          "Quality reports",
-        ],
+    },
+    notFound: {
+      kicker: "404 / route not found",
+      title: "Signal lost, page not found.",
+      prefix: "The route",
+      suffix:
+        "does not exist in this portfolio. Head back to the main page or continue from the experience overview.",
+      actions: {
+        home: "Home",
+        experience: "Experience",
       },
-      {
-        title: "Development",
-        tools: [
-          "TypeScript",
-          "JavaScript",
-          "Kotlin basics",
-          "Remix",
-          "HTML",
-          "CSS",
-          "React",
-          "Next.js",
-          "Node.js",
-          "Tailwind CSS",
-          "Prisma",
-          "PostgreSQL",
-          "Java",
-        ],
-      },
-      {
-        title: "Platforms, integrations & AI",
-        tools: [
-          "Android testing",
-          "iOS testing",
-          "Git",
-          "Firebase",
-          "Stripe",
-          "InPost API",
-          "Cloudinary",
-          "Resend",
-          "Google Sheets API",
-          "GitHub Copilot",
-          "AI agents",
-          "MCP basics",
-          "AI testing",
-        ],
-      },
-    ],
+    },
   },
-};
-
-export const contactContent = {
-  kicker: "Contact",
-  title: "Let’s talk quality, automation or product delivery.",
-  description:
-    "Send a concise note and I will get back with context. For a faster signal, include the product area, stack and what kind of QA support you are looking for.",
-};
-
-export const notFoundContent = {
-  kicker: "404 / route not found",
-  title: "Signal lost, page not found.",
-  prefix: "The route",
-  suffix:
-    "does not exist in this portfolio. Head back to the main page or continue from the experience overview.",
-  actions: {
-    home: "Home",
-    experience: "Experience",
+  pl: {
+    languageName: "Polski",
+    languageToggleLabel: "Zmień język",
+    profile: {
+      brand: "Inżynieria Jakości",
+      heroRole: "Specjalista Quality Engineering",
+      currentFocus: "Inżynieria jakości, automatyzacja i dostarczanie produktu.",
+    },
+    navigation: {
+      home: "Start",
+      experience: "Doświadczenie",
+      skills: "Kompetencje",
+      certifications: "Certyfikaty",
+      github: "GitHub",
+      contact: "Kontakt",
+    },
+    home: {
+      typing: {
+        staticText: "Jestem",
+        words: [
+          "Test Automation Engineer",
+          "Specjalista Quality Engineering",
+          "Product-minded QA",
+          "Praktyk AI-assisted testing",
+        ],
+      },
+      heroCopy:
+        "Pomagam zespołom dostarczać bezpieczniejsze produkty dzięki praktycznej strategii jakości, stabilnej automatyzacji i produktowemu podejściu do testowania.",
+      careerSnapshot: [
+        {
+          label: "10+ lat",
+          value: "IT, QA i jakość produktu",
+        },
+        {
+          label: "Automation focus",
+          value: "Web, mobile, API i contract testing",
+        },
+        {
+          label: "Product builder",
+          value: "E-commerce, logistyka i IoT",
+        },
+      ],
+      actions: {
+        experience: "Zobacz doświadczenie",
+        contact: "Kontakt",
+      },
+      currentFocusLabel: "Aktualny focus",
+      visitorsLabel: "Odwiedziny",
+    },
+    experience: {
+      hero: {
+        kicker: "Resume",
+        title: "Doświadczenie",
+        description:
+          "Oś czasu pracy w obszarze quality engineering, automatyzacji, dostarczania produktu i budowania produktu w domenach logistyki, bankowości, web, mobile oraz smart home.",
+      },
+      summary: [
+        {
+          label: "Aktualny zakres",
+          title: "Quality engineering",
+          description:
+            "Automatyzacja, kontrakty, API, mobile i sygnały gotowości release.",
+        },
+        {
+          label: "Product ownership",
+          title: "ZabawkowyBox.pl",
+          description: "Subskrypcje e-commerce, płatności, CMS i operacje.",
+        },
+        {
+          label: "Ścieżka techniczna",
+          title: "Automation practice",
+          description:
+            "Playwright, WebdriverIO, API, CI/CD i workflowy wspierane AI.",
+        },
+      ],
+      sections: {
+        experience: "Doświadczenie",
+        education: "Edukacja",
+      },
+      cta: {
+        title: "Porozmawiajmy",
+        description:
+          "Jeśli chcesz dowiedzieć się więcej, sprawdź mój profil LinkedIn.",
+        button: "Otwórz LinkedIn",
+      },
+    },
+    skills: {
+      hero: {
+        kicker: "Capability map",
+        title: "Kompetencje wokół stabilnego delivery",
+        description:
+          "Praktyczny zestaw QA obejmujący automatyzację, analizę ryzyka i współpracę delivery. Mniej buzzwordów, więcej sygnałów pomagających dowozić z pewnością.",
+      },
+      summary: [
+        {
+          label: "Strategia",
+          title: "Risk-based QA",
+          description: "Decyzje o pokryciu testami oparte o ryzyko produktu i release.",
+        },
+        {
+          label: "Automatyzacja",
+          title: "Praktyczne pokrycie",
+          description: "Testy UI, API i mobile projektowane z myślą o utrzymaniu.",
+        },
+        {
+          label: "Delivery",
+          title: "Sygnały jakości",
+          description: "Czytelny feedback dla zespołów, stakeholderów i release.",
+        },
+      ],
+      bridge: {
+        kicker: "Jak to dziala",
+        title: "Od ryzyka release do praktycznej realizacji",
+        description:
+          "Podsumowanie wyżej pokazuje sposób pracy. Sekcje niżej przekładają go na codzienną odpowiedzialność QA: planowanie, automatyzację, defekty, środowiska, raportowanie i współpracę.",
+      },
+      capabilities: [
+        {
+          label: "Główne odpowiedzialności",
+          title: "Właścicielstwo quality delivery",
+          description:
+            "Planowanie, wykonanie i raportowanie pomagające zespołom rozumieć gotowość release.",
+          points: [
+            "Tworzenie i utrzymanie planów testów oraz przypadków testowych dla aplikacji mobile i desktop",
+            "Wykonywanie testów manualnych i automatycznych weryfikujących wymagania",
+            "Analiza wyników testów, monitorowanie metryk jakości i raportowanie sygnałów release",
+          ],
+        },
+        {
+          label: "Quality operations",
+          title: "Kontrola defektów, środowisk i danych",
+          description:
+            "Operacyjne praktyki QA, które utrzymują testy jako wiarygodne, powtarzalne i użyteczne.",
+          points: [
+            "Identyfikacja, dokumentowanie i śledzenie bugów oraz problemów klientów",
+            "Tworzenie i utrzymanie środowisk oraz danych testowych",
+            "Troubleshooting i wsparcie analizy przyczyn źródłowych",
+          ],
+        },
+        {
+          label: "Kompetencje",
+          title: "Współpraca i jakość produktu",
+          description:
+            "Praca cross-funkcyjna wspierająca delivery, feedback i ciągłe usprawnianie.",
+          points: [
+            "Współpraca z developerami, stakeholderami i zespołami wsparcia",
+            "Code review z perspektywy jakości",
+            "Wsparcie pracy agile, dokumentacji i rozwiązywania problemów",
+          ],
+        },
+      ],
+      stack: {
+        kicker: "Tech stack",
+        title: "Narzędzia, o których mogę rozmawiać z kontekstem",
+        description:
+          "Pogrupowane według tego, jak wspierają pracę nad jakością, a nie jako płaska lista technologii.",
+        groups: [
+          {
+            title: "Automation & testing",
+            tools: [
+              "Playwright",
+              "WebdriverIO",
+              "Appium",
+              "Postman",
+              "SoapUI",
+              "Gatling",
+              "Cucumber",
+              "REST API testing",
+              "SOAP API testing",
+              "Contract testing",
+              "WCAG",
+              "Cypress",
+              "Detox",
+              "K6",
+            ],
+          },
+          {
+            title: "QA operations",
+            tools: [
+              "Jira",
+              "Xray",
+              "TestRail",
+              "Confluence",
+              "CI/CD quality gates",
+              "GitHub Actions",
+              "Quality reports",
+            ],
+          },
+          {
+            title: "Development",
+            tools: [
+              "TypeScript",
+              "JavaScript",
+              "Kotlin basics",
+              "Remix",
+              "HTML",
+              "CSS",
+              "React",
+              "Next.js",
+              "Node.js",
+              "Tailwind CSS",
+              "Prisma",
+              "PostgreSQL",
+              "Java",
+            ],
+          },
+          {
+            title: "Platforms, integrations & AI",
+            tools: [
+              "Android testing",
+              "iOS testing",
+              "Git",
+              "Firebase",
+              "Stripe",
+              "InPost API",
+              "Cloudinary",
+              "Resend",
+              "Google Sheets API",
+              "GitHub Copilot",
+              "AI agents",
+              "MCP basics",
+              "AI testing",
+            ],
+          },
+        ],
+      },
+    },
+    contact: {
+      kicker: "Kontakt",
+      title: "Porozmawiajmy o jakości, automatyzacji albo delivery produktu.",
+      description:
+        "Napisz krótko, a wrócę z konkretnym kontekstem. Najszybciej zadziała informacja o obszarze produktu, stacku i rodzaju wsparcia QA, którego szukasz.",
+      form: {
+        fields: [
+          { id: "first_name", label: "Imię", type: "text" },
+          { id: "title", label: "Temat", type: "text" },
+          { id: "senderEmail", label: "Email", type: "email" },
+          { id: "message", label: "Wiadomość", rows: 5, type: "textarea" },
+        ],
+        errors: {
+          first_name: "Imię jest wymagane",
+          title: "Temat jest wymagany",
+          senderEmailRequired: "Email jest wymagany",
+          senderEmailInvalid: "Adres email jest niepoprawny",
+          message: "Wiadomość jest wymagana",
+        },
+        submit: "Wyślij wiadomość",
+        submitting: "Wysyłanie...",
+        success: "Wiadomość została wysłana.",
+        missingConfig: "Serwis email nie jest skonfigurowany.",
+        invalidPublicKey:
+          "Serwis email ma niepoprawny public key. Zaktualizuj konfigurację EmailJS.",
+        genericError:
+          "Nie udało się wysłać wiadomości. Sprawdź konfigurację formularza albo spróbuj ponownie później.",
+      },
+    },
+    notFound: {
+      kicker: "404 / nie znaleziono strony",
+      title: "Sygnał zgubiony, strony nie ma.",
+      prefix: "Ścieżka",
+      suffix:
+        "nie istnieje w tym portfolio. Wróć na stronę główną albo przejdź do przeglądu doświadczenia.",
+      actions: {
+        home: "Start",
+        experience: "Doświadczenie",
+      },
+    },
   },
 };

--- a/src/content/portfolioContent.js
+++ b/src/content/portfolioContent.js
@@ -71,7 +71,8 @@ export const portfolioContent = {
         {
           label: "Product ownership",
           title: "ZabawkowyBox.pl",
-          description: "E-commerce subscriptions, payments, CMS and operations.",
+          description:
+            "E-commerce subscriptions, payments, CMS and operations.",
         },
         {
           label: "Technical path",
@@ -107,7 +108,8 @@ export const portfolioContent = {
         {
           label: "Automation",
           title: "Practical coverage",
-          description: "UI, API and mobile checks designed for maintainability.",
+          description:
+            "UI, API and mobile checks designed for maintainability.",
         },
         {
           label: "Delivery",
@@ -258,8 +260,7 @@ export const portfolioContent = {
       externalWork: {
         kicker: "Supporting work",
         title: "Articles and side projects",
-        description:
-          "These are useful as secondary proof points, so they live here rather than competing with the primary portfolio navigation.",
+        description: "Additional materials showcasing practical experience.",
         items: [
           {
             title: "QA Journey",
@@ -337,6 +338,9 @@ export const portfolioContent = {
       linkedinAria: "Open LinkedIn profile",
       linkedinTitle: "Open LinkedIn",
     },
+    footer: {
+      rights: "All rights reserved.",
+    },
     common: {
       loading: "Loading...",
       close: "Close",
@@ -348,7 +352,8 @@ export const portfolioContent = {
     profile: {
       brand: "Inżynieria Jakości",
       heroRole: "Specjalista ds. inżynierii jakości",
-      currentFocus: "Inżynieria jakości, automatyzacja i dostarczanie produktu.",
+      currentFocus:
+        "Inżynieria jakości, automatyzacja i dostarczanie produktu.",
     },
     navigation: {
       home: "Start",
@@ -509,17 +514,20 @@ export const portfolioContent = {
         {
           label: "Strategia",
           title: "QA oparte na ryzyku",
-          description: "Decyzje o pokryciu testami oparte o ryzyko produktu i wydania.",
+          description:
+            "Decyzje o pokryciu testami oparte o ryzyko produktu i wydania.",
         },
         {
           label: "Automatyzacja",
           title: "Praktyczne pokrycie testami",
-          description: "Testy UI, API i mobile projektowane z myślą o utrzymaniu.",
+          description:
+            "Testy UI, API i mobile projektowane z myślą o utrzymaniu.",
         },
         {
           label: "Dostarczanie",
           title: "Sygnały jakości",
-          description: "Czytelna informacja zwrotna dla zespołów, interesariuszy i wydań.",
+          description:
+            "Czytelna informacja zwrotna dla zespołów, interesariuszy i wydań.",
         },
       ],
       bridge: {
@@ -567,7 +575,7 @@ export const portfolioContent = {
         kicker: "Stack technologiczny",
         title: "Narzędzia, o których mogę rozmawiać z kontekstem",
         description:
-          "Pogrupowane według tego, jak wspierają pracę nad jakością, a nie jako płaska lista technologii.",
+          "Pogrupowane według tego, jak wspierają pracę nad jakością.",
         groups: [
           {
             title: "Automation & testing",
@@ -665,8 +673,7 @@ export const portfolioContent = {
       externalWork: {
         kicker: "Dodatkowe materiały",
         title: "Artykuły i projekty poboczne",
-        description:
-          "To dodatkowe punkty potwierdzające praktykę, dlatego są tutaj, a nie w głównej nawigacji portfolio.",
+        description: "Dodatkowe materiały pokazujące praktyczne doświadczenie.",
         items: [
           {
             title: "QA Journey",
@@ -700,7 +707,8 @@ export const portfolioContent = {
     },
     contact: {
       kicker: "Kontakt",
-      title: "Porozmawiajmy o jakości, automatyzacji albo dostarczaniu produktu.",
+      title:
+        "Porozmawiajmy o jakości, automatyzacji albo dostarczaniu produktu.",
       description:
         "Napisz krótko, a wrócę z konkretnym kontekstem. Najszybciej zadziała informacja o obszarze produktu, stacku i rodzaju wsparcia QA, którego szukasz.",
       form: {
@@ -743,6 +751,9 @@ export const portfolioContent = {
       githubTitle: "Otwórz GitHub",
       linkedinAria: "Otwórz profil LinkedIn",
       linkedinTitle: "Otwórz LinkedIn",
+    },
+    footer: {
+      rights: "Wszelkie prawa zastrzeżone.",
     },
     common: {
       loading: "Ładowanie...",

--- a/src/content/portfolioContent.js
+++ b/src/content/portfolioContent.js
@@ -276,7 +276,7 @@ export const portfolioContent = {
     languageToggleLabel: "Zmień język",
     profile: {
       brand: "Inżynieria Jakości",
-      heroRole: "Specjalista Quality Engineering",
+      heroRole: "Specjalista ds. inżynierii jakości",
       currentFocus: "Inżynieria jakości, automatyzacja i dostarczanie produktu.",
     },
     navigation: {
@@ -291,10 +291,10 @@ export const portfolioContent = {
       typing: {
         staticText: "Jestem",
         words: [
-          "Test Automation Engineer",
-          "Specjalista Quality Engineering",
-          "Product-minded QA",
-          "Praktyk AI-assisted testing",
+          "inżynierem automatyzacji testów",
+          "specjalistą ds. inżynierii jakości",
+          "QA z podejściem produktowym",
+          "praktykiem testowania wspieranego AI",
         ],
       },
       heroCopy:
@@ -305,11 +305,11 @@ export const portfolioContent = {
           value: "IT, QA i jakość produktu",
         },
         {
-          label: "Automation focus",
-          value: "Web, mobile, API i contract testing",
+          label: "Obszar automatyzacji",
+          value: "Testy web, mobile, API i kontraktowe",
         },
         {
-          label: "Product builder",
+          label: "Twórca produktu",
           value: "E-commerce, logistyka i IoT",
         },
       ],
@@ -317,33 +317,33 @@ export const portfolioContent = {
         experience: "Zobacz doświadczenie",
         contact: "Kontakt",
       },
-      currentFocusLabel: "Aktualny focus",
+      currentFocusLabel: "Aktualny obszar",
       visitorsLabel: "Odwiedziny",
     },
     experience: {
       hero: {
-        kicker: "Resume",
+        kicker: "CV",
         title: "Doświadczenie",
         description:
-          "Oś czasu pracy w obszarze quality engineering, automatyzacji, dostarczania produktu i budowania produktu w domenach logistyki, bankowości, web, mobile oraz smart home.",
+          "Oś czasu pracy w obszarze inżynierii jakości, automatyzacji, dostarczania produktu i budowania rozwiązań w domenach logistyki, bankowości, web, mobile oraz smart home.",
       },
       summary: [
         {
           label: "Aktualny zakres",
-          title: "Quality engineering",
+          title: "Inżynieria jakości",
           description:
-            "Automatyzacja, kontrakty, API, mobile i sygnały gotowości release.",
+            "Automatyzacja, kontrakty, API, mobile i sygnały gotowości wydania.",
         },
         {
-          label: "Product ownership",
+          label: "Produkt własny",
           title: "ZabawkowyBox.pl",
           description: "Subskrypcje e-commerce, płatności, CMS i operacje.",
         },
         {
           label: "Ścieżka techniczna",
-          title: "Automation practice",
+          title: "Praktyka automatyzacji",
           description:
-            "Playwright, WebdriverIO, API, CI/CD i workflowy wspierane AI.",
+            "Playwright, WebdriverIO, API, CI/CD i przepływy pracy wspierane AI.",
         },
       ],
       sections: {
@@ -356,51 +356,111 @@ export const portfolioContent = {
           "Jeśli chcesz dowiedzieć się więcej, sprawdź mój profil LinkedIn.",
         button: "Otwórz LinkedIn",
       },
+      timeline: {
+        experiences: [
+          {
+            title: "Twórca i inżynier produktu",
+            time: "Projekt produktowy – obecnie",
+            description:
+              "Stworzyłem i utrzymuję subskrypcyjną platformę e-commerce do wypożyczania zabawek opartą o Remix, React, TypeScript, Tailwind CSS, Prisma i PostgreSQL. Odpowiadam za konta użytkowników, cykliczne płatności Stripe, panele klienta i administratora, blog/CMS, media w Cloudinary, maile Resend/Nodemailer, integrację z punktami InPost i automatyzacje operacyjne w Google Sheets.",
+          },
+          {
+            title: "Starszy inżynier QA",
+            description:
+              "Buduję i utrzymuję automatyczne pokrycie jakościowe dla warstw web, mobile, backend, kontraktów i wydajności. Pracuję z Playwrightem w TypeScript, WebdriverIO dla aplikacji natywnych, kotlinowymi frameworkami testów backendowych oraz testami wydajnościowymi Gatling. Dostarczam raporty jakości, dokumentację i czytelną analizę defektów wspierającą decyzje o wydaniu.",
+          },
+          {
+            title: "Ekspert ds. testów",
+            description:
+              "Odpowiadałem za pokrycie testami funkcjonalnymi, regresyjnymi, walidacyjnymi i WCAG dla aplikacji bankowych na mobile i desktop. Przekładałem user stories na scenariusze testowe, raportowałem defekty w Jira/Xray i wspierałem pewność wydań.",
+          },
+          {
+            title: "Tester oprogramowania",
+            description:
+              "Realizowałem testy integracyjne, funkcjonalne, regresyjne i walidację danych dla przepływów iOS oraz Android. Budowałem automatyczne sprawdzenia i dokumentację użytkownika, żeby ograniczać tarcie we wsparciu i poprawiać niezawodność produktu.",
+          },
+          {
+            title: "Full-stack developer — praktyka",
+            description:
+              "Budowałem i testowałem platformę e-learningową z użyciem React, Next.js, Node.js i NestJS. Ćwiczyłem code review, poprawę niezawodności i produktowe myślenie end-to-end z perspektywy developera oraz QA.",
+          },
+          {
+            title: "Koordynator QA",
+            description:
+              "Koordynowałem prace mobile QA, odpowiadałem za cykl życia przypadków testowych w TestRail i śledziłem delivery w Jira. Wspierałem estymacje, planowanie i usprawnienia procesu, żeby jakość była widoczna w trakcie wydań.",
+          },
+          {
+            title: "Inżynier QA",
+            description:
+              "Walidowałem aplikacje mobile i web przez testy eksploracyjne, regresyjne i automatyczne z użyciem Detox oraz Cypress. Utrzymywałem pokrycie w TestRail i pomagałem usprawniać powtarzalne sprawdzenia przed wydaniem.",
+          },
+          {
+            title: "Inżynier wsparcia technicznego",
+            description:
+              "Wspierałem użytkowników systemów inteligentnego domu i przekładałem powtarzalne problemy na czytelne zgłoszenia defektów. Utrzymywałem dokumentację w Confluence, obsługiwałem zgłoszenia w Desk.com i łączyłem informacje zwrotne od klientów z zespołami produktowymi.",
+          },
+          {
+            title: "Młodszy inżynier systemów IT",
+            description:
+              "Zapewniałem wsparcie IT dla wewnętrznych zespołów inżynieryjnych, w tym konfigurację sprzętu i oprogramowania oraz obsługę zgłoszeń w narzędziach ITSM. Zbudowałem fundament w obszarze infrastruktury, operacji wsparcia i jakości usług.",
+          },
+        ],
+        education: [
+          {
+            title: "Magister inżynier elektrotechniki",
+            studies: "Politechnika Poznańska",
+          },
+          {
+            title: "Inżynier elektrotechniki",
+            studies: "Politechnika Poznańska",
+          },
+        ],
+      },
     },
     skills: {
       hero: {
-        kicker: "Capability map",
-        title: "Kompetencje wokół stabilnego delivery",
+        kicker: "Mapa kompetencji",
+        title: "Kompetencje wokół stabilnych wydań",
         description:
-          "Praktyczny zestaw QA obejmujący automatyzację, analizę ryzyka i współpracę delivery. Mniej buzzwordów, więcej sygnałów pomagających dowozić z pewnością.",
+          "Praktyczny zestaw kompetencji QA obejmujący automatyzację, analizę ryzyka i współpracę z zespołami delivery. Mniej buzzwordów, więcej sygnałów pomagających dowozić z pewnością.",
       },
       summary: [
         {
           label: "Strategia",
-          title: "Risk-based QA",
-          description: "Decyzje o pokryciu testami oparte o ryzyko produktu i release.",
+          title: "QA oparte na ryzyku",
+          description: "Decyzje o pokryciu testami oparte o ryzyko produktu i wydania.",
         },
         {
           label: "Automatyzacja",
-          title: "Praktyczne pokrycie",
+          title: "Praktyczne pokrycie testami",
           description: "Testy UI, API i mobile projektowane z myślą o utrzymaniu.",
         },
         {
-          label: "Delivery",
+          label: "Dostarczanie",
           title: "Sygnały jakości",
-          description: "Czytelny feedback dla zespołów, stakeholderów i release.",
+          description: "Czytelna informacja zwrotna dla zespołów, interesariuszy i wydań.",
         },
       ],
       bridge: {
-        kicker: "Jak to dziala",
-        title: "Od ryzyka release do praktycznej realizacji",
+        kicker: "Jak to działa",
+        title: "Od ryzyka wydania do praktycznej realizacji",
         description:
           "Podsumowanie wyżej pokazuje sposób pracy. Sekcje niżej przekładają go na codzienną odpowiedzialność QA: planowanie, automatyzację, defekty, środowiska, raportowanie i współpracę.",
       },
       capabilities: [
         {
           label: "Główne odpowiedzialności",
-          title: "Właścicielstwo quality delivery",
+          title: "Odpowiedzialność za jakość dostarczania",
           description:
-            "Planowanie, wykonanie i raportowanie pomagające zespołom rozumieć gotowość release.",
+            "Planowanie, wykonanie i raportowanie pomagające zespołom rozumieć gotowość wydania.",
           points: [
             "Tworzenie i utrzymanie planów testów oraz przypadków testowych dla aplikacji mobile i desktop",
             "Wykonywanie testów manualnych i automatycznych weryfikujących wymagania",
-            "Analiza wyników testów, monitorowanie metryk jakości i raportowanie sygnałów release",
+            "Analiza wyników testów, monitorowanie metryk jakości i raportowanie sygnałów gotowości wydania",
           ],
         },
         {
-          label: "Quality operations",
+          label: "Operacje jakościowe",
           title: "Kontrola defektów, środowisk i danych",
           description:
             "Operacyjne praktyki QA, które utrzymują testy jako wiarygodne, powtarzalne i użyteczne.",
@@ -414,16 +474,16 @@ export const portfolioContent = {
           label: "Kompetencje",
           title: "Współpraca i jakość produktu",
           description:
-            "Praca cross-funkcyjna wspierająca delivery, feedback i ciągłe usprawnianie.",
+            "Praca cross-funkcyjna wspierająca dostarczanie produktu, informację zwrotną i ciągłe usprawnianie.",
           points: [
-            "Współpraca z developerami, stakeholderami i zespołami wsparcia",
+            "Współpraca z developerami, interesariuszami i zespołami wsparcia",
             "Code review z perspektywy jakości",
             "Wsparcie pracy agile, dokumentacji i rozwiązywania problemów",
           ],
         },
       ],
       stack: {
-        kicker: "Tech stack",
+        kicker: "Stack technologiczny",
         title: "Narzędzia, o których mogę rozmawiać z kontekstem",
         description:
           "Pogrupowane według tego, jak wspierają pracę nad jakością, a nie jako płaska lista technologii.",

--- a/src/context/LanguageContext.jsx
+++ b/src/context/LanguageContext.jsx
@@ -1,0 +1,85 @@
+import React from "react";
+
+import {
+  defaultLanguage,
+  portfolioContent,
+  supportedLanguages,
+} from "../content/portfolioContent";
+
+const STORAGE_KEY = "portfolio-language";
+
+const LanguageContext = React.createContext(null);
+
+const getBrowserLanguage = () => {
+  if (typeof navigator === "undefined") {
+    return defaultLanguage;
+  }
+
+  return navigator.language?.slice(0, 2).toLowerCase();
+};
+
+const getInitialLanguage = () => {
+  if (typeof window === "undefined") {
+    return defaultLanguage;
+  }
+
+  const storedLanguage = window.localStorage.getItem(STORAGE_KEY);
+  if (supportedLanguages.includes(storedLanguage)) {
+    return storedLanguage;
+  }
+
+  const browserLanguage = getBrowserLanguage();
+  return supportedLanguages.includes(browserLanguage)
+    ? browserLanguage
+    : defaultLanguage;
+};
+
+export const LanguageProvider = ({ children }) => {
+  const [language, setLanguageState] = React.useState(getInitialLanguage);
+
+  const setLanguage = React.useCallback((nextLanguage) => {
+    if (!supportedLanguages.includes(nextLanguage)) {
+      return;
+    }
+
+    setLanguageState(nextLanguage);
+    window.localStorage.setItem(STORAGE_KEY, nextLanguage);
+  }, []);
+
+  const toggleLanguage = React.useCallback(() => {
+    const currentIndex = supportedLanguages.indexOf(language);
+    const nextIndex = (currentIndex + 1) % supportedLanguages.length;
+    setLanguage(supportedLanguages[nextIndex]);
+  }, [language, setLanguage]);
+
+  React.useEffect(() => {
+    document.documentElement.lang = language;
+  }, [language]);
+
+  const value = React.useMemo(
+    () => ({
+      content: portfolioContent[language],
+      language,
+      setLanguage,
+      supportedLanguages,
+      toggleLanguage,
+    }),
+    [language, setLanguage, toggleLanguage]
+  );
+
+  return (
+    <LanguageContext.Provider value={value}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => {
+  const context = React.useContext(LanguageContext);
+
+  if (!context) {
+    throw new Error("useLanguage must be used within LanguageProvider");
+  }
+
+  return context;
+};

--- a/src/features/certification/Certifications.jsx
+++ b/src/features/certification/Certifications.jsx
@@ -1,12 +1,15 @@
 import React, { useContext, useState, useEffect } from "react";
 
 import { DataContext } from "../../context/DataContext";
+import { useLanguage } from "../../context/LanguageContext";
 
 import CertificationCard from "./CertificationCard";
 
 const Certifications = () => {
   const [visibleCertifications, setVisibleCertifications] = useState([]);
   const { certificationCourses } = useContext(DataContext);
+  const { content } = useLanguage();
+  const certificationsContent = content.certifications;
 
   useEffect(() => {
     certificationCourses.forEach((_, index) => {
@@ -19,12 +22,9 @@ const Certifications = () => {
   return (
     <div className="content certifications-page">
       <header className="section-hero">
-        <p className="section-kicker">Continuous learning</p>
-        <h1>Certifications</h1>
-        <p>
-          A curated training record across test automation, AI, accessibility,
-          performance, web development and networking foundations.
-        </p>
+        <p className="section-kicker">{certificationsContent.hero.kicker}</p>
+        <h1>{certificationsContent.hero.title}</h1>
+        <p>{certificationsContent.hero.description}</p>
       </header>
       <div className="certification-courses">
         {certificationCourses.map((course, index) => (

--- a/src/features/contact/ContactForm.css
+++ b/src/features/contact/ContactForm.css
@@ -1,10 +1,10 @@
 .contact-page {
-  align-items: center;
+  align-items: start;
   display: grid;
   gap: clamp(24px, 5vw, 70px);
-  grid-template-columns: minmax(0, 0.9fr) minmax(320px, 480px);
+  grid-template-columns: minmax(0, 0.88fr) minmax(340px, 500px);
   margin: 0 auto;
-  max-width: 1120px;
+  max-width: 1220px;
   min-height: calc(100vh - 112px);
   padding: clamp(28px, 5vw, 56px) 24px;
   width: 100%;
@@ -16,10 +16,13 @@
 
 .contact-intro h1 {
   color: #f8fafc;
-  font-size: clamp(2.2rem, 5vw, 4.4rem);
+  font-size: clamp(2.15rem, 3.4vw, 3.7rem);
   font-weight: 900;
   line-height: 1.02;
   margin: 0;
+  max-width: 680px;
+  overflow-wrap: anywhere;
+  text-wrap: balance;
 }
 
 .contact-intro > p:not(.section-kicker) {

--- a/src/features/contact/ContactForm.jsx
+++ b/src/features/contact/ContactForm.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import emailjs from "emailjs-com";
-import { contactContent } from "../../content/portfolioContent";
+import { useLanguage } from "../../context/LanguageContext";
 import SocialLinks from "../../shared/SocialLinks";
 import "./ContactForm.css";
 
@@ -13,30 +13,6 @@ const initialFormData = {
 
 const emailPattern = /\S+@\S+\.\S+/;
 
-const formFields = [
-  {
-    id: "first_name",
-    label: "Name",
-    type: "text",
-  },
-  {
-    id: "title",
-    label: "Subject",
-    type: "text",
-  },
-  {
-    id: "senderEmail",
-    label: "Email",
-    type: "email",
-  },
-  {
-    id: "message",
-    label: "Message",
-    rows: 5,
-    type: "textarea",
-  },
-];
-
 const getEmailConfig = () => ({
   serviceID: process.env.REACT_APP_EMAILJS_SERVICE_ID,
   templateID: process.env.REACT_APP_EMAILJS_TEMPLATE_ID,
@@ -47,6 +23,9 @@ const getEmailConfig = () => ({
 
 const ContactForm = () => {
   const [formData, setFormData] = useState(initialFormData);
+  const { content } = useLanguage();
+  const contactContent = content.contact;
+  const { form } = contactContent;
 
   const [errors, setErrors] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -64,14 +43,14 @@ const ContactForm = () => {
   const validate = () => {
     const errors = {};
     if (!formData.first_name.trim())
-      errors.first_name = "First name is required";
-    if (!formData.title.trim()) errors.title = "Title is required";
+      errors.first_name = form.errors.first_name;
+    if (!formData.title.trim()) errors.title = form.errors.title;
     if (!formData.senderEmail.trim()) {
-      errors.senderEmail = "Email is required";
+      errors.senderEmail = form.errors.senderEmailRequired;
     } else if (!emailPattern.test(formData.senderEmail)) {
-      errors.senderEmail = "Email address is invalid";
+      errors.senderEmail = form.errors.senderEmailInvalid;
     }
-    if (!formData.message.trim()) errors.message = "Message is required";
+    if (!formData.message.trim()) errors.message = form.errors.message;
 
     return errors;
   };
@@ -93,7 +72,7 @@ const ContactForm = () => {
     if (!serviceID || !templateID || !publicKey) {
       setIsSubmitting(false);
       setFeedbackType("error");
-      setFeedbackMessage("Email service is not configured.");
+      setFeedbackMessage(form.missingConfig);
       return;
     }
 
@@ -110,7 +89,7 @@ const ContactForm = () => {
     try {
       await emailjs.send(serviceID, templateID, templateParams, publicKey);
       setFeedbackType("success");
-      setFeedbackMessage("Your message has been sent successfully.");
+      setFeedbackMessage(form.success);
       setFormData(initialFormData);
     } catch (error) {
       console.error("EmailJS send failed:", error);
@@ -118,8 +97,8 @@ const ContactForm = () => {
       setFeedbackType("error");
       setFeedbackMessage(
         errorText.includes("Public Key")
-          ? "Email service has an invalid public key. Please update the EmailJS configuration."
-          : "The message could not be sent. Please check the form configuration or try again later."
+          ? form.invalidPublicKey
+          : form.genericError
       );
     } finally {
       setIsSubmitting(false);
@@ -136,7 +115,7 @@ const ContactForm = () => {
       </section>
 
       <form id="contact-form" className="contact-form" onSubmit={handleSubmit}>
-        {formFields.map(({ id, label, rows, type }) => {
+        {form.fields.map(({ id, label, rows, type }) => {
           const Field = type === "textarea" ? "textarea" : "input";
 
           return (
@@ -157,7 +136,7 @@ const ContactForm = () => {
         })}
 
         <button type="submit" disabled={isSubmitting}>
-          {isSubmitting ? "Sending..." : "Send Message"}
+          {isSubmitting ? form.submitting : form.submit}
         </button>
         {feedbackMessage && (
           <p className={`form-feedback ${feedbackType}`}>{feedbackMessage}</p>

--- a/src/features/experience/ExperiencePage.jsx
+++ b/src/features/experience/ExperiencePage.jsx
@@ -41,7 +41,7 @@ const ExperiencePage = () => {
   }, []);
 
   if (!experiences || experiences.length === 0) {
-    return <div className="spinner">Loading...</div>;
+    return <div className="spinner">{content.common.loading}</div>;
   }
 
   const displayedExperiences =

--- a/src/features/experience/ExperiencePage.jsx
+++ b/src/features/experience/ExperiencePage.jsx
@@ -5,11 +5,13 @@ import "aos/dist/aos.css";
 
 import { DataContext } from "../../context/DataContext";
 import { profile } from "../../config/profile";
-import { experienceContent } from "../../content/portfolioContent";
+import { useLanguage } from "../../context/LanguageContext";
 import "./ExperiencePage.css";
 
 const ExperiencePage = () => {
   const { experiences, education } = React.useContext(DataContext);
+  const { content } = useLanguage();
+  const experienceContent = content.experience;
   const expRef = React.useRef(null);
   const eduRef = React.useRef(null);
   const [expLineStyle, setExpLineStyle] = React.useState({});
@@ -57,14 +59,8 @@ const ExperiencePage = () => {
           </article>
         ))}
       </section>
-      <div
-        className="timeline-line"
-        style={expLineStyle}
-      />
-      <div
-        className="timeline-line"
-        style={eduLineStyle}
-      />
+      <div className="timeline-line" style={expLineStyle} />
+      <div className="timeline-line" style={eduLineStyle} />
       <section ref={expRef} className="timeline-section">
         <h2 className="timeline-section-title" data-aos="zoom-in">
           {experienceContent.sections.experience}
@@ -100,7 +96,6 @@ const ExperiencePage = () => {
             <div className="timeline-card">
               <h3>{edu.title}</h3>
               <span>{edu.studies}</span>
-              <p className="timeline-time">{edu.time}</p>
             </div>
             <div className="timeline-icon">
               <FaGraduationCap />

--- a/src/features/experience/ExperiencePage.jsx
+++ b/src/features/experience/ExperiencePage.jsx
@@ -67,7 +67,10 @@ const ExperiencePage = () => {
         <h1>{experienceContent.hero.title}</h1>
         <p>{experienceContent.hero.description}</p>
       </header>
-      <section className="experience-summary" aria-label="Experience summary">
+      <section
+        className="experience-summary"
+        aria-label={experienceContent.summaryLabel}
+      >
         {experienceContent.summary.map((item) => (
           <article key={item.label}>
             <span>{item.label}</span>

--- a/src/features/experience/ExperiencePage.jsx
+++ b/src/features/experience/ExperiencePage.jsx
@@ -10,8 +10,9 @@ import "./ExperiencePage.css";
 
 const ExperiencePage = () => {
   const { experiences, education } = React.useContext(DataContext);
-  const { content } = useLanguage();
+  const { content, language } = useLanguage();
   const experienceContent = content.experience;
+  const timelineTranslations = experienceContent.timeline;
   const expRef = React.useRef(null);
   const eduRef = React.useRef(null);
   const [expLineStyle, setExpLineStyle] = React.useState({});
@@ -43,6 +44,22 @@ const ExperiencePage = () => {
     return <div className="spinner">Loading...</div>;
   }
 
+  const displayedExperiences =
+    language === "pl" && timelineTranslations?.experiences
+      ? experiences.map((experience, index) => ({
+          ...experience,
+          ...timelineTranslations.experiences[index],
+        }))
+      : experiences;
+
+  const displayedEducation =
+    language === "pl" && timelineTranslations?.education
+      ? education.map((educationItem, index) => ({
+          ...educationItem,
+          ...timelineTranslations.education[index],
+        }))
+      : education;
+
   return (
     <div className="experience-page">
       <header className="section-hero">
@@ -65,7 +82,7 @@ const ExperiencePage = () => {
         <h2 className="timeline-section-title" data-aos="zoom-in">
           {experienceContent.sections.experience}
         </h2>
-        {experiences.map((exp, index) => (
+        {displayedExperiences.map((exp, index) => (
           <div
             key={index}
             className={`timeline-item ${index % 2 === 0 ? "is-right" : "is-left"}`}
@@ -87,7 +104,7 @@ const ExperiencePage = () => {
         <h2 className="timeline-section-title" data-aos="zoom-in">
           {experienceContent.sections.education}
         </h2>
-        {education.map((edu, index) => (
+        {displayedEducation.map((edu, index) => (
           <div
             key={index}
             className={`timeline-item ${index % 2 === 0 ? "is-right" : "is-left"}`}

--- a/src/features/github/GithubRepositories.jsx
+++ b/src/features/github/GithubRepositories.jsx
@@ -1,40 +1,15 @@
 import React, { useState, useEffect } from "react";
 
+import { useLanguage } from "../../context/LanguageContext";
 import GithubCard from "./GithubRepositoriesCard";
-
-const externalWork = [
-  {
-    title: "QA Journey",
-    description: "Writing and notes around quality assurance practice.",
-    url: "https://qa-journey.blogspot.com/",
-  },
-  {
-    title: "Quality Assurance Blog",
-    description: "Additional QA articles and experiments.",
-    url: "https://qa-blog.onrender.com/",
-  },
-  {
-    title: "JS & React Fundamentals",
-    description: "Learning lab for JavaScript, React and Next.js fundamentals.",
-    url: "https://learn-js-react-basics.vercel.app/",
-  },
-  {
-    title: "Mini Game Collection",
-    description: "Small frontend projects focused on interaction and polish.",
-    url: "https://mini-game-collection.vercel.app/",
-  },
-  {
-    title: "My Smart Home",
-    description: "Smart home related page and domain project.",
-    url: "https://mysmarthome.cba.pl/",
-  },
-];
 
 const GithubRepositories = () => {
   const [repos, setRepos] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [visibleRepos, setVisibleRepos] = useState([]);
+  const { content } = useLanguage();
+  const githubContent = content.github;
 
   useEffect(() => {
     const fetchRepoData = async () => {
@@ -73,20 +48,17 @@ const GithubRepositories = () => {
         <div className="spinner border-t-4 border-blue-500 rounded-full w-12 h-12 animate-spin"></div>
       </div>
     );
-  if (error) return <div>Error: {error}</div>;
+  if (error) return <div>{githubContent.errorPrefix}: {error}</div>;
 
   return (
     <div className="content github-page">
       <header className="section-hero">
-        <p className="section-kicker">Build log</p>
-        <h1>GitHub repositories</h1>
-        <p>
-          Projects, experiments and learning repos that show how I approach
-          automation, frontend foundations and practical engineering.
-        </p>
+        <p className="section-kicker">{githubContent.hero.kicker}</p>
+        <h1>{githubContent.hero.title}</h1>
+        <p>{githubContent.hero.description}</p>
       </header>
       {repos.length === 0 ? (
-        <div>Coming soon. Under construction.</div>
+        <div>{githubContent.emptyState}</div>
       ) : (
         <div className="repo-grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {repos.map((repo, index) => (
@@ -96,24 +68,21 @@ const GithubRepositories = () => {
                 visibleRepos.includes(index)
                   ? "transform translate-y-0 opacity-100"
                   : "transform translate-y-20 opacity-0"
-              }`}
+            }`}
             >
-              <GithubCard repo={repo} />
+              <GithubCard repo={repo} content={githubContent.card} />
             </div>
           ))}
         </div>
       )}
       <section className="external-work-section">
         <div className="stack-heading">
-          <p className="section-kicker">Supporting work</p>
-          <h2>Articles and side projects</h2>
-          <p>
-            These are useful as secondary proof points, so they live here rather
-            than competing with the primary portfolio navigation.
-          </p>
+          <p className="section-kicker">{githubContent.externalWork.kicker}</p>
+          <h2>{githubContent.externalWork.title}</h2>
+          <p>{githubContent.externalWork.description}</p>
         </div>
         <div className="external-work-grid">
-          {externalWork.map((item) => (
+          {githubContent.externalWork.items.map((item) => (
             <a
               href={item.url}
               target="_blank"

--- a/src/features/github/GithubRepositoriesCard.jsx
+++ b/src/features/github/GithubRepositoriesCard.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { FaCodeBranch, FaExternalLinkAlt, FaStar } from "react-icons/fa";
 
-const GithubCard = ({ repo }) => {
+const GithubCard = ({ content, repo }) => {
   return (
     <article className="repo-box">
       <div className="repo-card-header">
@@ -11,13 +11,13 @@ const GithubCard = ({ repo }) => {
           target="_blank"
           rel="noopener noreferrer"
           className="repo-link"
-          aria-label={`Open ${repo.name} on GitHub`}
+          aria-label={`${content.openLabelPrefix} ${repo.name} ${content.openLabelSuffix}`}
         >
           <FaExternalLinkAlt />
         </a>
       </div>
       <p className="repo-description">
-        {repo.description || "No description provided yet."}
+        {repo.description || content.fallbackDescription}
       </p>
       <div className="repo-meta">
         {repo.language && <span>{repo.language}</span>}
@@ -29,7 +29,7 @@ const GithubCard = ({ repo }) => {
         </span>
       </div>
       <a href={repo.html_url} target="_blank" rel="noopener noreferrer">
-        View repository
+        {content.viewRepository}
       </a>
     </article>
   );

--- a/src/features/mainPage/MainPage.jsx
+++ b/src/features/mainPage/MainPage.jsx
@@ -51,7 +51,7 @@ const MainPage = () => {
             words={home.typing.words}
           />
           <p className="hero-copy">{home.heroCopy}</p>
-          <dl className="career-snapshot" aria-label="Career snapshot">
+          <dl className="career-snapshot" aria-label={home.careerSnapshotLabel}>
             {home.careerSnapshot.map((item) => (
               <div key={item.label}>
                 <dt>{item.label}</dt>

--- a/src/features/mainPage/MainPage.jsx
+++ b/src/features/mainPage/MainPage.jsx
@@ -8,13 +8,15 @@ import { db, analytics } from "../../firebase";
 
 import TypingEffect from "../../components/typing/TypingEffect";
 import { profile } from "../../config/profile";
-import { homeContent } from "../../content/portfolioContent";
+import { useLanguage } from "../../context/LanguageContext";
 import SocialLinks from "../../shared/SocialLinks";
 
 import "./MainPage.css";
 
 const MainPage = () => {
   const [visitCount, setVisitCount] = React.useState(0);
+  const { content } = useLanguage();
+  const { home, profile: profileContent } = content;
 
   React.useEffect(() => {
     const incrementVisitCount = async () => {
@@ -42,12 +44,15 @@ const MainPage = () => {
     <div className="main-page">
       <div className="content-wrapper">
         <div className="left-section">
-          <div className="hero-kicker">{profile.heroRole}</div>
+          <div className="hero-kicker">{profileContent.heroRole}</div>
           <h1 className="hero-name">{profile.name}</h1>
-          <TypingEffect />
-          <p className="hero-copy">{homeContent.heroCopy}</p>
+          <TypingEffect
+            staticText={home.typing.staticText}
+            words={home.typing.words}
+          />
+          <p className="hero-copy">{home.heroCopy}</p>
           <dl className="career-snapshot" aria-label="Career snapshot">
-            {homeContent.careerSnapshot.map((item) => (
+            {home.careerSnapshot.map((item) => (
               <div key={item.label}>
                 <dt>{item.label}</dt>
                 <dd>{item.value}</dd>
@@ -56,10 +61,10 @@ const MainPage = () => {
           </dl>
           <div className="hero-actions">
             <Link to="/experience" className="primary-action">
-              View Experience <FaArrowRight aria-hidden="true" />
+              {home.actions.experience} <FaArrowRight aria-hidden="true" />
             </Link>
             <Link to="/contact" className="secondary-action">
-              <FaEnvelope aria-hidden="true" /> Contact
+              <FaEnvelope aria-hidden="true" /> {home.actions.contact}
             </Link>
           </div>
         </div>
@@ -72,8 +77,8 @@ const MainPage = () => {
               className="profile-image"
             />
             <div className="profile-panel">
-              <span>{homeContent.currentFocusLabel}</span>
-              <p>{profile.currentFocus}</p>
+              <span>{home.currentFocusLabel}</span>
+              <p>{profileContent.currentFocus}</p>
             </div>
           </div>
         </div>
@@ -84,7 +89,7 @@ const MainPage = () => {
 
         <div className="visit-counter-container">
           <p className="visit-counter">
-            {homeContent.visitorsLabel}: <span>{visitCount}</span>
+            {home.visitorsLabel}: <span>{visitCount}</span>
           </p>
         </div>
       </div>

--- a/src/features/notFound/NotFound.jsx
+++ b/src/features/notFound/NotFound.jsx
@@ -2,11 +2,13 @@ import React from "react";
 import { FaArrowLeft, FaHome } from "react-icons/fa";
 import { Link, useLocation } from "react-router-dom";
 
-import { notFoundContent } from "../../content/portfolioContent";
+import { useLanguage } from "../../context/LanguageContext";
 import "./NotFound.css";
 
 const NotFound = () => {
   const location = useLocation();
+  const { content } = useLanguage();
+  const notFoundContent = content.notFound;
 
   return (
     <section className="not-found-page">

--- a/src/features/skills/Skills.jsx
+++ b/src/features/skills/Skills.jsx
@@ -1,7 +1,10 @@
 import "./Skills.css";
-import { skillsContent } from "../../content/portfolioContent";
+import { useLanguage } from "../../context/LanguageContext";
 
 const Skills = () => {
+  const { content } = useLanguage();
+  const skillsContent = content.skills;
+
   return (
     <div className="skills-page">
       <header className="section-hero">

--- a/src/features/skills/Skills.jsx
+++ b/src/features/skills/Skills.jsx
@@ -12,7 +12,7 @@ const Skills = () => {
         <h1>{skillsContent.hero.title}</h1>
         <p>{skillsContent.hero.description}</p>
       </header>
-      <section className="skills-summary" aria-label="Skills summary">
+      <section className="skills-summary" aria-label={skillsContent.summaryLabel}>
         {skillsContent.summary.map((item) => (
           <article key={item.label}>
             <span>{item.label}</span>
@@ -21,12 +21,15 @@ const Skills = () => {
           </article>
         ))}
       </section>
-      <section className="skills-bridge" aria-label="Capability context">
+      <section className="skills-bridge" aria-label={skillsContent.bridge.ariaLabel}>
         <p className="section-kicker">{skillsContent.bridge.kicker}</p>
         <h2>{skillsContent.bridge.title}</h2>
         <p>{skillsContent.bridge.description}</p>
       </section>
-      <section className="capability-showcase" aria-label="Core capabilities">
+      <section
+        className="capability-showcase"
+        aria-label={skillsContent.capabilitiesLabel}
+      >
         {skillsContent.capabilities.map((capability, index) => (
           <article className="capability-card" key={capability.title}>
             <div className="capability-index">0{index + 1}</div>

--- a/src/shared/Footer.jsx
+++ b/src/shared/Footer.jsx
@@ -1,12 +1,15 @@
 import React from "react";
 
+import { useLanguage } from "../context/LanguageContext";
+
 const Footer = () => {
   const currentYear = new Date().getFullYear();
+  const { content } = useLanguage();
 
   return (
     <footer className="footer">
       <p>© {currentYear} Adateo Rafał Ciesielski</p>
-      <p>All rights reserved.</p>
+      <p>{content.footer.rights}</p>
     </footer>
   );
 };

--- a/src/shared/SocialLinks.jsx
+++ b/src/shared/SocialLinks.jsx
@@ -1,40 +1,45 @@
 import { FaGithub, FaLinkedin } from "react-icons/fa";
 
 import { profile } from "../config/profile";
+import { useLanguage } from "../context/LanguageContext";
 
 const socialLinks = [
   {
-    ariaLabel: "Open LinkedIn profile",
+    ariaKey: "linkedinAria",
     className: "linkedin",
     href: profile.links.linkedin,
     Icon: FaLinkedin,
-    title: "Open LinkedIn",
+    titleKey: "linkedinTitle",
   },
   {
-    ariaLabel: "Open GitHub profile",
+    ariaKey: "githubAria",
     className: "github",
     href: profile.links.github,
     Icon: FaGithub,
-    title: "Open GitHub",
+    titleKey: "githubTitle",
   },
 ];
 
-const SocialLinks = ({ className = "social-icons" }) => (
-  <div className={className}>
-    {socialLinks.map(({ ariaLabel, className, href, Icon, title }) => (
-      <a
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label={ariaLabel}
-        className={`icon ${className}`}
-        title={title}
-        key={href}
-      >
-        <Icon size={30} />
-      </a>
-    ))}
-  </div>
-);
+const SocialLinks = ({ className = "social-icons" }) => {
+  const { content } = useLanguage();
+
+  return (
+    <div className={className}>
+      {socialLinks.map(({ ariaKey, className, href, Icon, titleKey }) => (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={content.social[ariaKey]}
+          className={`icon ${className}`}
+          title={content.social[titleKey]}
+          key={href}
+        >
+          <Icon size={30} />
+        </a>
+      ))}
+    </div>
+  );
+};
 
 export default SocialLinks;

--- a/src/shared/navbar/NavBar.css
+++ b/src/shared/navbar/NavBar.css
@@ -71,6 +71,13 @@
   padding: 4px;
 }
 
+.navbar-language-item {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  padding: 6px 4px;
+}
+
 .navbar-menu-item a {
   --nav-corner-cut: 7px;
   background: transparent;
@@ -131,6 +138,36 @@
   transform: translateY(-1px) scale(1.02);
 }
 
+.language-toggle {
+  align-items: center;
+  background: rgba(15, 23, 42, 0.72);
+  border: 1px solid rgba(54, 241, 205, 0.22);
+  display: inline-flex;
+  gap: 3px;
+  padding: 3px;
+}
+
+.language-toggle button {
+  background: transparent;
+  border: 0;
+  color: #94a3b8;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  padding: 7px 9px;
+  transition:
+    background 0.18s ease,
+    color 0.18s ease;
+}
+
+.language-toggle button:hover,
+.language-toggle button.active {
+  background: rgba(54, 241, 205, 0.12);
+  color: #7cf7dc;
+}
+
 @media (min-width: 768px) {
   .navbar {
     align-items: center;
@@ -149,6 +186,7 @@
 
   .navbar-menu {
     display: flex;
+    align-items: center;
     justify-content: flex-end;
     gap: 4px;
     position: static;

--- a/src/shared/navbar/Navbar.jsx
+++ b/src/shared/navbar/Navbar.jsx
@@ -27,7 +27,9 @@ const NavBar = () => {
           onClick={toggleMenu}
           className="navbar-menu-btn"
           aria-label={
-            menuOpen ? "Close navigation menu" : "Open navigation menu"
+            menuOpen
+              ? content.navigation.closeMenu
+              : content.navigation.openMenu
           }
           aria-expanded={menuOpen}
         >

--- a/src/shared/navbar/Navbar.jsx
+++ b/src/shared/navbar/Navbar.jsx
@@ -2,17 +2,19 @@ import React from "react";
 import { NavLink } from "react-router-dom";
 import { FaBars, FaTimes } from "react-icons/fa";
 
-import { navigationItems, profile } from "../../config/profile";
+import { navigationItems } from "../../config/profile";
+import { useLanguage } from "../../context/LanguageContext";
 import "./NavBar.css";
 
-const BrandLink = ({ className = "", onClick }) => (
+const BrandLink = ({ brand, className = "", onClick }) => (
   <NavLink to="/" className={`navbar-title ${className}`} onClick={onClick}>
-    RC<span>{profile.brand}</span>
+    RC<span>{brand}</span>
   </NavLink>
 );
 
 const NavBar = () => {
   const [menuOpen, setMenuOpen] = React.useState(false);
+  const { content, language, setLanguage, supportedLanguages } = useLanguage();
 
   const closeMenu = () => setMenuOpen(false);
   const toggleMenu = () => setMenuOpen((isOpen) => !isOpen);
@@ -20,7 +22,7 @@ const NavBar = () => {
   return (
     <nav className="navbar">
       <div className="navbar-toggle">
-        <BrandLink onClick={closeMenu} />
+        <BrandLink brand={content.profile.brand} onClick={closeMenu} />
         <button
           onClick={toggleMenu}
           className="navbar-menu-btn"
@@ -32,15 +34,34 @@ const NavBar = () => {
           {menuOpen ? <FaTimes /> : <FaBars />}
         </button>
       </div>
-      <BrandLink className="navbar-title-desktop" onClick={closeMenu} />
+      <BrandLink
+        brand={content.profile.brand}
+        className="navbar-title-desktop"
+        onClick={closeMenu}
+      />
       <ul className={`navbar-menu ${menuOpen ? "active" : ""}`}>
         {navigationItems.map((item) => (
           <li className="navbar-menu-item" key={item.path}>
             <NavLink to={item.path} onClick={closeMenu}>
-              {item.label}
+              {content.navigation[item.key]}
             </NavLink>
           </li>
         ))}
+        <li className="navbar-language-item">
+          <div className="language-toggle" aria-label={content.languageToggleLabel}>
+            {supportedLanguages.map((languageCode) => (
+              <button
+                aria-pressed={languageCode === language}
+                className={languageCode === language ? "active" : ""}
+                key={languageCode}
+                onClick={() => setLanguage(languageCode)}
+                type="button"
+              >
+                {languageCode.toUpperCase()}
+              </button>
+            ))}
+          </div>
+        </li>
       </ul>
     </nav>
   );


### PR DESCRIPTION
## Summary
- Add a lightweight EN/PL language foundation with persisted language selection.
- Move visible portfolio copy into centralized content dictionaries and wire Home, Experience, Skills, Certifications, GitHub, Contact, 404, social labels, footer, and accessibility labels to the active language.
- Add Polish timeline overrides and clean up education timeline dates.
- Update the portfolio smoke test so it validates the real app instead of the old CRA placeholder.