### PR TITLE
Update privacy policy

### DIFF
--- a/src/features/privacy/PrivacyPolicy.css
+++ b/src/features/privacy/PrivacyPolicy.css
@@ -2,34 +2,42 @@
   max-width: 850px;
   margin: 60px auto;
   padding: 30px;
-  background: rgba(189, 189, 189, 0.9);
-  box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.1);
-  border-radius: 10px;
+  background: linear-gradient(
+    180deg,
+    rgba(15, 23, 42, 0.9),
+    rgba(15, 23, 42, 0.72)
+  );
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.28);
+  border-radius: 8px;
   text-align: left;
 }
 
 .privacy-container h1,
 .privacy-container h2 {
-  color: #2c3e50;
+  color: #f8fafc;
 }
 
 .privacy-container h1 {
+  font-family: var(--font-display);
   text-align: center;
   font-size: 32px;
+  line-height: 1.05;
   margin-bottom: 20px;
 }
 
 .privacy-container h2 {
   font-size: 24px;
   margin-top: 30px;
-  border-bottom: 2px solid #2c3e50;
+  border-bottom: 1px solid rgba(54, 241, 205, 0.32);
   padding-bottom: 5px;
 }
 
 .privacy-container p {
   font-size: 18px;
   margin-bottom: 15px;
-  color: #363636;
+  color: #cbd5e1;
+  line-height: 1.7;
 }
 
 .privacy-container ul {
@@ -40,16 +48,17 @@
 .privacy-container li {
   margin-bottom: 10px;
   font-size: 18px;
+  color: #cbd5e1;
+  line-height: 1.6;
+}
+
+.privacy-container strong {
+  color: #f8fafc;
 }
 
 .privacy-container a {
-  color: #dadcde;
   text-decoration: none;
   font-weight: bold;
-}
-
-.privacy-container a:hover {
-  text-decoration: underline;
 }
 
 .privacy-contact-link {
@@ -57,15 +66,39 @@
   text-align: center;
   margin-top: 20px;
   padding: 12px 20px;
-  background: #16589a;
-  color: #fff;
+  background: #36f1cd;
+  color: #031014;
   font-size: 18px;
-  font-weight: bold;
+  font-weight: 900;
   text-decoration: none;
+  color: #031014;
   border-radius: 8px;
-  transition: background 0.3s ease-in-out;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
 }
 
 .privacy-contact-link:hover {
-  background: #0056b3;
+  opacity: 0.9;
+  transform: translateY(-2px);
+}
+
+@media (max-width: 700px) {
+  .privacy-container {
+    margin: 30px 16px 64px;
+    padding: 22px;
+  }
+
+  .privacy-container h1 {
+    font-size: 28px;
+  }
+
+  .privacy-container h2 {
+    font-size: 21px;
+  }
+
+  .privacy-container p,
+  .privacy-container li {
+    font-size: 16px;
+  }
 }

--- a/src/features/privacy/PrivacyPolicy.css
+++ b/src/features/privacy/PrivacyPolicy.css
@@ -71,7 +71,6 @@
   font-size: 18px;
   font-weight: 900;
   text-decoration: none;
-  color: #031014;
   border-radius: 8px;
   transition:
     opacity 0.2s ease,

--- a/src/features/privacy/PrivacyPolicy.jsx
+++ b/src/features/privacy/PrivacyPolicy.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import "./PrivacyPolicy.css";
 
 const PrivacyPolicy = () => {
@@ -112,10 +113,10 @@ const PrivacyPolicy = () => {
       <p>
         If you have any privacy questions or requests, contact us using the
         form.
-        <a href="/contact" className="privacy-contact-link">
-          Open contact form
-        </a>
       </p>
+      <Link to="/contact" className="privacy-contact-link">
+        Open contact form
+      </Link>
     </div>
   );
 };

--- a/src/features/privacy/PrivacyPolicy.jsx
+++ b/src/features/privacy/PrivacyPolicy.jsx
@@ -6,49 +6,114 @@ const PrivacyPolicy = () => {
     <div className="privacy-container">
       <h1>Privacy Policy</h1>
       <p>
-        <strong>Last Updated:</strong> 07.02.2025
+        <strong>Last updated:</strong> 01.06.2026
       </p>
       <p>
-        This Privacy Policy applies to all applications and services provided by{" "}
-        <strong>Adateo Rafał Ciesielski</strong>.
+        This Privacy Policy applies to apps and related services published by{" "}
+        <strong>Adateo Rafał Ciesielski</strong>, including products distributed
+        through Google Play or other app stores.
       </p>
 
-      <h2>1. Introduction</h2>
+      <h2>1. Developer and contact</h2>
       <p>
-        This Privacy Policy explains how we collect, use, and protect your
-        information when you use our applications or services.
+        For privacy questions, data deletion requests, or parent/guardian
+        requests, use the privacy point of contact below.
       </p>
 
-      <h2>2. Information We Collect</h2>
-      <p>We may collect the following types of information:</p>
+      <h2>2. Information we collect</h2>
+      <p>
+        The apps are designed to collect only data needed to provide and improve
+        the educational experience:
+      </p>
       <ul>
         <li>
-          <strong>Personal Data:</strong> Only if voluntarily provided, such as
-          name and email (for support requests).
+          <strong>Support data:</strong> name, email address, and message
+          content only when you contact us voluntarily.
         </li>
         <li>
-          <strong>Non-Personal Data:</strong> Device type, OS version, app usage
-          analytics, crash logs.
+          <strong>Diagnostics:</strong> device model, operating system version,
+          app version, crash logs, and basic usage events used to fix bugs and
+          improve app quality.
         </li>
         <li>
-          <strong>Location Data:</strong> Some apps may request access to
-          location data (only if explicitly allowed).
+          <strong>Learning data:</strong> progress, answers, scores, settings,
+          or preferences when an app needs them for its educational features.
+          This data is stored locally unless a specific app clearly explains
+          that cloud sync or account features are available.
+        </li>
+        <li>
+          <strong>Google Play data:</strong> purchase, subscription, install, or
+          review information may be processed by Google Play when you use Google
+          Play features.
         </li>
       </ul>
-
-      <h2>3. How We Use Your Information</h2>
-      <p>We use collected data for the following purposes:</p>
-      <ul>
-        <li>To improve app functionality and user experience.</li>
-        <li>To provide customer support and respond to inquiries.</li>
-        <li>To analyze app performance and fix bugs.</li>
-      </ul>
-
-      <h2>4. Contact</h2>
       <p>
-        If you have any questions, use below button
-        <a href="/portfolio/#/contact" className="privacy-contact-link">
-          contact us using the form
+        The apps do not request precise location, contacts, photos, microphone,
+        camera, or similar sensitive permissions unless a specific feature
+        clearly requires it and the permission prompt is shown by the device.
+      </p>
+
+      <h2>3. How we use information</h2>
+      <p>Collected data is used only for these purposes:</p>
+      <ul>
+        <li>to provide educational features and remember app settings,</li>
+        <li>to respond to support or privacy requests,</li>
+        <li>to diagnose crashes, fix bugs, and improve reliability,</li>
+        <li>to comply with Google Play and legal obligations.</li>
+      </ul>
+
+      <h2>4. Sharing and third parties</h2>
+      <p>
+        We do not sell user data and do not use educational app data for
+        behavioral advertising. Data may be processed by trusted service
+        providers that help operate the apps and this website, such as Google
+        Play services, app distribution and hosting providers, analytics or
+        crash reporting services, and EmailJS for contact form delivery. Data
+        may also be shared if required by law or to protect users, the apps, or
+        the developer.
+      </p>
+
+      <h2>5. Security</h2>
+      <p>
+        We use reasonable technical and organizational safeguards for personal
+        and sensitive user data. Access is limited to what is needed to operate,
+        support, and improve the apps. No method of storage or transmission is
+        perfectly secure, but we avoid collecting unnecessary data.
+      </p>
+
+      <h2>6. Retention and deletion</h2>
+      <p>
+        Support messages are retained only as long as needed to answer the
+        request and maintain necessary records. Diagnostics and analytics are
+        retained according to the settings of the service provider. Locally
+        stored learning data can usually be removed by clearing app data or
+        uninstalling the app. You may request deletion of personal data by using
+        the contact link below.
+      </p>
+
+      <h2>7. Children and students</h2>
+      <p>
+        The apps may be used for education by children or students. We do not
+        knowingly collect more personal data from children than is needed for an
+        educational feature, support, safety, or legal compliance. We do not
+        sell children&apos;s data or serve behavioral advertising based on
+        children&apos;s activity. Parents or guardians can contact us to ask
+        about data access, correction, or deletion.
+      </p>
+
+      <h2>8. Changes</h2>
+      <p>
+        We may update this Privacy Policy when app features, providers, or legal
+        requirements change. The latest version will remain available at this
+        public URL.
+      </p>
+
+      <h2>9. Contact</h2>
+      <p>
+        If you have any privacy questions or requests, contact us using the
+        form.
+        <a href="/contact" className="privacy-contact-link">
+          Open contact form
         </a>
       </p>
     </div>

--- a/src/features/privacy/PrivacyPolicy.test.jsx
+++ b/src/features/privacy/PrivacyPolicy.test.jsx
@@ -1,8 +1,16 @@
 import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import PrivacyPolicy from "./PrivacyPolicy";
 
+const renderPrivacyPolicy = () =>
+  render(
+    <MemoryRouter>
+      <PrivacyPolicy />
+    </MemoryRouter>
+  );
+
 test("includes Google Play privacy policy essentials for apps and services", () => {
-  render(<PrivacyPolicy />);
+  renderPrivacyPolicy();
 
   expect(
     screen.getByRole("heading", { name: /privacy policy/i })
@@ -14,4 +22,13 @@ test("includes Google Play privacy policy essentials for apps and services", () 
   expect(screen.getByText(/We do not sell user data/i)).toBeInTheDocument();
   expect(screen.getByText(/Retention and deletion/i)).toBeInTheDocument();
   expect(screen.getByText(/Children and students/i)).toBeInTheDocument();
+});
+
+test("keeps the contact call to action outside the paragraph copy", () => {
+  const { container } = renderPrivacyPolicy();
+
+  const contactLink = screen.getByRole("link", { name: /open contact form/i });
+
+  expect(contactLink).toHaveAttribute("href", "/contact");
+  expect(container.querySelector("p .privacy-contact-link")).not.toBeInTheDocument();
 });

--- a/src/features/privacy/PrivacyPolicy.test.jsx
+++ b/src/features/privacy/PrivacyPolicy.test.jsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import PrivacyPolicy from "./PrivacyPolicy";
+
+test("includes Google Play privacy policy essentials for apps and services", () => {
+  render(<PrivacyPolicy />);
+
+  expect(
+    screen.getByRole("heading", { name: /privacy policy/i })
+  ).toBeInTheDocument();
+  expect(screen.getAllByText(/Adateo Rafał Ciesielski/i)).toHaveLength(1);
+  expect(screen.getByText(/privacy point of contact/i)).toBeInTheDocument();
+  expect(screen.getByText(/apps and related services/i)).toBeInTheDocument();
+  expect(screen.queryByText(/Expo|React Native/i)).not.toBeInTheDocument();
+  expect(screen.getByText(/We do not sell user data/i)).toBeInTheDocument();
+  expect(screen.getByText(/Retention and deletion/i)).toBeInTheDocument();
+  expect(screen.getByText(/Children and students/i)).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- Updates the privacy policy copy to be generic for apps and related services, while preserving Google Play essentials for educational use cases.
- Removes duplicated developer naming in the opening section.
- Aligns the privacy policy styling with the darker portfolio UI and adds a focused content regression test.

## Validation
- CI=true WATCHMAN_DISABLE=1 npm test -- --watchAll=false
- npm run build

## Notes
- Local gh auth status reports an invalid token.